### PR TITLE
added null ptr check to CameraRenderer

### DIFF
--- a/src/components/camera/Camera.cpp
+++ b/src/components/camera/Camera.cpp
@@ -154,6 +154,8 @@ void CameraRenderer::updateWindowId () {
 
 bool CameraRenderer::notifyReceivedVideoSize () const {
   shared_ptr<const linphone::VideoDefinition> videoDefinition = mCall->getCurrentParams()->getReceivedVideoDefinition();
+  if(! (videoDefinition)) {
+    return false;
   unsigned int width = videoDefinition->getWidth();
   unsigned int height = videoDefinition->getHeight();
 


### PR DESCRIPTION
Scenario: auto answer video call. Bug: app might segfault when the calling party quickly disconnects the call while on your end the video is still rendering its first frame. Not easy to replicate, happens only once in every +- 10 trials.