### PR TITLE
Fix: add request access for microphone on macOS.

### DIFF
--- a/linphone-app/cmake_builder/linphone_package/macos/Info.plist.in
+++ b/linphone-app/cmake_builder/linphone_package/macos/Info.plist.in
@@ -52,5 +52,7 @@
 	<string>True</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Streaming Video between devices</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Linphone requires microphone access for VoIP communication.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fix for https://github.com/BelledonneCommunications/linphone-desktop/issues/285
Solution is to require microphone access in Info.plist