### PR TITLE
Attended Transfer

### DIFF
--- a/linphone-app/assets/languages/en.ts
+++ b/linphone-app/assets/languages/en.ts
@@ -423,6 +423,14 @@
         <source>callPause</source>
         <translation>HOLD CALL</translation>
     </message>
+    <message>
+        <source>attendedTransferCall</source>
+        <translation>ATTENDED TRANSFER CALL</translation>
+    </message>
+    <message>
+        <source>attendedTransferComplete</source>
+        <translation>COMPLETE ATTENDED TRANSFER</translation>
+    </message>
 </context>
 <context>
     <name>CallsWindow</name>

--- a/linphone-app/src/components/call/CallModel.cpp
+++ b/linphone-app/src/components/call/CallModel.cpp
@@ -207,11 +207,32 @@ void CallModel::askForTransfer () {
   CoreManager::getInstance()->getCallsListModel()->askForTransfer(this);
 }
 
+void CallModel::askForAttendedTransfer () {
+  CoreManager::getInstance()->getCallsListModel()->askForAttendedTransfer(this);
+}
+
 bool CallModel::transferTo (const QString &sipAddress) {
   bool status = !!mCall->transfer(Utils::appStringToCoreString(sipAddress));
-  if (status)
+  if (status) {
     qWarning() << QStringLiteral("Unable to transfer: `%1`.").arg(sipAddress);
-  return status;
+    return false;
+  }
+  return true;
+}
+
+bool CallModel::transferToAnother (const QString &peerAddress) {
+  qInfo() << QStringLiteral("Transferring to another: `%1`.").arg(peerAddress);
+  CallModel *transferCallModel = CoreManager::getInstance()->getCallsListModel()->findCallModelFromPeerAddress(peerAddress);
+  if (transferCallModel == nullptr) {
+    qWarning() << QStringLiteral("Unable to transfer to another: `%1` (peer not found)").arg(peerAddress);
+    return false;
+  }
+  bool status = !!transferCallModel->mCall->transferToAnother(mCall);
+  if (status) {
+    qWarning() << QStringLiteral("Unable to transfer to another: `%1` (transfer failed)").arg(peerAddress);
+    return false;
+  }
+  return true;
 }
 
 // -----------------------------------------------------------------------------

--- a/linphone-app/src/components/call/CallModel.hpp
+++ b/linphone-app/src/components/call/CallModel.hpp
@@ -68,6 +68,8 @@ class CallModel : public QObject {
   Q_PROPERTY(float speakerVolumeGain READ getSpeakerVolumeGain WRITE setSpeakerVolumeGain NOTIFY speakerVolumeGainChanged);
   Q_PROPERTY(float microVolumeGain READ getMicroVolumeGain WRITE setMicroVolumeGain NOTIFY microVolumeGainChanged);
 
+  Q_PROPERTY(QString transferAddress READ getTransferAddress WRITE setTransferAddress NOTIFY transferAddressChanged);
+
 public:
   enum CallStatus {
     CallStatusConnected,
@@ -115,7 +117,9 @@ public:
   Q_INVOKABLE void terminate ();
 
   Q_INVOKABLE void askForTransfer ();
+  Q_INVOKABLE void askForAttendedTransfer ();
   Q_INVOKABLE bool transferTo (const QString &sipAddress);
+  Q_INVOKABLE bool transferToAnother (const QString &peerAddress);
 
   Q_INVOKABLE void acceptVideoRequest ();
   Q_INVOKABLE void rejectVideoRequest ();
@@ -135,12 +139,20 @@ public:
   
   void setRemoteDisplayName(const std::string& name);
 
+  QString getTransferAddress () const {
+    return mTransferAddress;
+  }
+  void setTransferAddress (const QString &transferAddress) {
+    mTransferAddress = transferAddress;
+    emit transferAddressChanged(mTransferAddress);
+  }
+
   static constexpr int DtmfSoundDelay = 200;
   
   std::shared_ptr<linphone::Call> mCall;
   std::shared_ptr<linphone::Address> mRemoteAddress;
   std::shared_ptr<linphone::MagicSearch> mMagicSearch;
-  
+
 public slots:
 // Set remote display name when a search has been done
   void searchReceived(std::list<std::shared_ptr<linphone::SearchResult>> results);
@@ -157,6 +169,7 @@ signals:
   void securityUpdated ();
   void speakerVolumeGainChanged (float volume);
   void microVolumeGainChanged (float volume);
+  void transferAddressChanged (const QString &transferAddress);
 
   void cameraFirstFrameReceived (unsigned int width, unsigned int height);
   
@@ -243,6 +256,8 @@ private:
   QVariantList mAudioStats;
   QVariantList mVideoStats;
   std::shared_ptr<SearchHandler> mSearch;
+
+  QString mTransferAddress;
 };
 
 #endif // CALL_MODEL_H_

--- a/linphone-app/src/components/calls/CallsListModel.hpp
+++ b/linphone-app/src/components/calls/CallsListModel.hpp
@@ -41,9 +41,12 @@ public:
   QVariant data (const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
   void askForTransfer (CallModel *callModel);
+  void askForAttendedTransfer (CallModel *callModel);
 
-  Q_INVOKABLE void launchAudioCall (const QString &sipAddress, const QHash<QString, QString> &headers = {}) const;
-  Q_INVOKABLE void launchVideoCall (const QString &sipAddress) const;
+  CallModel *findCallModelFromPeerAddress (const QString &peerAddress) const;
+
+  Q_INVOKABLE CallModel *launchAudioCall (const QString &sipAddress, const QHash<QString, QString> &headers = {}) const;
+  Q_INVOKABLE CallModel *launchVideoCall (const QString &sipAddress) const;
 
   Q_INVOKABLE int getRunningCallsNumber () const;
 
@@ -53,6 +56,7 @@ public:
 signals:
   void callRunning (int index, CallModel *callModel);
   void callTransferAsked (CallModel *callModel);
+  void callAttendedTransferAsked (CallModel *callModel);
 
   void callMissed (CallModel *callModel);
 

--- a/linphone-app/ui/modules/Linphone/Calls/Calls.js
+++ b/linphone-app/ui/modules/Linphone/Calls/Calls.js
@@ -46,11 +46,25 @@ function getParams (call) {
       })
     }
 
-    return {
-      actions: optActions.concat([{
+    if (call.transferAddress !== '') {
+      optActions.push({
+        handler: call.askForTransfer,
+        name: qsTr('attendedTransferComplete')
+      })
+    }
+    else {
+      optActions.push({
         handler: call.askForTransfer,
         name: qsTr('transferCall')
-      }, {
+      })
+      optActions.push({
+        handler: call.askForAttendedTransfer,
+        name: qsTr('attendedTransferCall')
+      })
+    }
+
+    return {
+      actions: optActions.concat([{
         handler: call.terminate,
         name: qsTr('terminateCall')
       }]),
@@ -110,11 +124,25 @@ function getParams (call) {
       })
     }
 
-    return {
-      actions: optActions.concat([{
+    if (call.transferAddress !== '') {
+      optActions.push({
+        handler: call.askForTransfer,
+        name: qsTr('attendedTransferComplete')
+      })
+    }
+    else {
+      optActions.push({
         handler: call.askForTransfer,
         name: qsTr('transferCall')
-      }, {
+      })
+      optActions.push({
+        handler: call.askForAttendedTransfer,
+        name: qsTr('attendedTransferCall')
+      })
+    }
+
+    return {
+      actions: optActions.concat([{
         handler: call.terminate,
         name: qsTr('terminateCall')
       }]),

--- a/linphone-app/ui/views/App/Calls/CallsWindow.js
+++ b/linphone-app/ui/views/App/Calls/CallsWindow.js
@@ -94,9 +94,34 @@ function handleCallTransferAsked (call) {
     return
   }
 
+  if (call.transferAddress !== '') {
+    console.debug('RucActiveCall.js: attended transfer to call ' + call.transferAddress)
+    call.transferToAnother(call.transferAddress)
+    return
+  }
+
   window.detachVirtualWindow()
   window.attachVirtualWindow(Qt.resolvedUrl('Dialogs/CallTransfer.qml'), {
-    call: call
+    call: call,
+    attended: false
+  })
+}
+
+function handleCallAttendedTransferAsked (call) {
+  if (!call) {
+    return
+  }
+
+  if (call.transferAddress !== '') {
+    console.debug('RucActiveCall.js: attended transfer to call ' + call.transferAddress)
+    call.transferToAnother(call.transferAddress)
+    return
+  }
+
+  window.detachVirtualWindow()
+  window.attachVirtualWindow(Qt.resolvedUrl('Dialogs/CallTransfer.qml'), {
+    call: call,
+    attended: true
   })
 }
 

--- a/linphone-app/ui/views/App/Calls/CallsWindow.js
+++ b/linphone-app/ui/views/App/Calls/CallsWindow.js
@@ -95,7 +95,7 @@ function handleCallTransferAsked (call) {
   }
 
   if (call.transferAddress !== '') {
-    console.debug('RucActiveCall.js: attended transfer to call ' + call.transferAddress)
+    console.debug('Attended transfer to call ' + call.transferAddress)
     call.transferToAnother(call.transferAddress)
     return
   }
@@ -113,7 +113,7 @@ function handleCallAttendedTransferAsked (call) {
   }
 
   if (call.transferAddress !== '') {
-    console.debug('RucActiveCall.js: attended transfer to call ' + call.transferAddress)
+    console.debug('Attended transfer to call ' + call.transferAddress)
     call.transferToAnother(call.transferAddress)
     return
   }

--- a/linphone-app/ui/views/App/Calls/CallsWindow.qml
+++ b/linphone-app/ui/views/App/Calls/CallsWindow.qml
@@ -241,6 +241,7 @@ Window {
   Connections {
     target: CallsListModel
     onCallTransferAsked: Logic.handleCallTransferAsked(callModel)
+    onCallAttendedTransferAsked: Logic.handleCallAttendedTransferAsked(callModel)
     onRowsRemoved: Logic.tryToCloseWindow()
   }
 }

--- a/linphone-app/ui/views/App/Calls/Dialogs/CallTransfer.qml
+++ b/linphone-app/ui/views/App/Calls/Dialogs/CallTransfer.qml
@@ -14,6 +14,7 @@ DialogPlus {
   // ---------------------------------------------------------------------------
 
   property var call
+  property bool attended: false
 
   // ---------------------------------------------------------------------------
 
@@ -81,7 +82,13 @@ DialogPlus {
             actions: [{
               icon: 'transfer',
               handler: function (entry) {
-                callTransfer.call.transferTo(entry.sipAddress)
+                if (attended) {
+                  var call = CallsListModel.launchAudioCall(entry.sipAddress)
+                  call.transferAddress = callTransfer.call.peerAddress
+                }
+                else {
+                  callTransfer.call.transferTo(entry.sipAddress)
+                }
                 exit(1)
               }
             }]


### PR DESCRIPTION
Added support for Attended Transfer as an additional option for transferring calls. Choosing ATTENDED TRANSFER CALL instead of TRANSFER CALL will result in a new consultation call being placed to the destination of the transfer. After consultation, choosing COMPLETE ATTENDED TRANSFER will result in a REFER with Replaces in the Refer-To header to seamlessly transfer the call to the destination without requiring another INVITE. Both transferred call and consultation call shojld terminate immediately after completing attended transfer.