### PR TITLE
Remove unused %1 variable in german home translation

### DIFF
--- a/linphone-app/assets/languages/de.ts
+++ b/linphone-app/assets/languages/de.ts
@@ -140,7 +140,7 @@
     </message>
     <message>
         <source>homeDescription</source>
-        <translation>Der Assistent hilft Ihnen das %1 Konto zu konfigurieren und zu nutzen.</translation>
+        <translation>Der Assistent hilft Ihnen das SIP-Konto zu konfigurieren und zu nutzen.</translation>
     </message>
     <message>
         <source>createAppSipAccount</source>


### PR DESCRIPTION
The english translation does not have the %1 variable anymore:
https://github.com/BelledonneCommunications/linphone-desktop/blob/3ea4dbd4ec6344468f22905415b4f6a0a2d6fc57/linphone-app/assets/languages/en.ts#L143