### PR TITLE
Fix en.ts (locked on Weblate)

### DIFF
--- a/Linphone/data/languages/en.ts
+++ b/Linphone/data/languages/en.ts
@@ -812,7 +812,7 @@
     <message>
         <location filename="../../core/App.cpp" line="1837"/>
         <source>mark_all_read_action</source>
-        <translation>Marquer tout comme lu</translation>
+        <translation>Mark all as read</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
This text in the English translation is still in French.
Unfortunately on Weblate the whole English translation is locked.
Hence the PR here.