### PR TITLE
Add auto-answer support for incoming calls

### DIFF
--- a/Linphone/model/core/CoreModel.cpp
+++ b/Linphone/model/core/CoreModel.cpp
@@ -29,6 +29,8 @@
 #include <QTimer>
 
 #include "core/App.hpp"
+#include "core/call/CallGui.hpp"
+#include "core/call/CallList.hpp"
 #include "core/notifier/Notifier.hpp"
 #include "core/path/Paths.hpp"
 #include "model/tool/ToolModel.hpp"
@@ -489,6 +491,26 @@ void CoreModel::onCallStateChanged(const std::shared_ptr<linphone::Core> &core,
 			command = command.replace("$1", userName);
 			command = command.replace("$2", displayName);
 			Utils::runCommandLine(command);
+		}
+		if (core->getConfig()->getBool(SettingsModel::UiSection, "auto_answer", false) &&
+		    !SettingsModel::dndEnabled(core->getConfig())) {
+			int delayMs = core->getConfig()->getInt(SettingsModel::UiSection, "auto_answer_delay", 0);
+			bool withVideo = core->getConfig()->getBool(SettingsModel::UiSection, "auto_answer_with_video", false);
+			lInfo() << log().arg("Auto-answer is enabled, accepting incoming call in %1 ms").arg(delayMs);
+			App::postCoreAsync([delayMs, withVideo]() {
+				QTimer::singleShot(delayMs, App::getInstance(), [withVideo]() {
+					const auto callList = App::getInstance()->getCallList();
+					if (!callList) return;
+					const auto pendingCall = callList->getFirstIncommingPendingCall();
+					if (pendingCall.isNull()) {
+						lWarning() << sLog().arg("Auto-answer timer fired but no pending incoming call was found");
+						return;
+					}
+					const auto gui = new CallGui(pendingCall);
+					Utils::openCallsWindow(gui);
+					pendingCall->lAccept(withVideo);
+				});
+			});
 		}
 	}
 	if (state == linphone::Call::State::End && SettingsModel::dndEnabled(core->getConfig()) &&


### PR DESCRIPTION
## What

Restores the auto-answer feature that existed in the GTK-era desktop app and is still documented on the Linphone wiki (linphonerc configuration file page), but has no implementation in the current Qt/QML desktop app. Related long-standing request: #89.

The feature honors the historically documented `[ui]` section keys, so existing configurations keep working:

```ini
[ui]
auto_answer=1              # enable auto-answer
auto_answer_delay=2000     # delay in ms before accepting (default 0)
auto_answer_with_video=0   # accept with video enabled (default off)
```

## How

In `CoreModel::onCallStateChanged`, when a call reaches `IncomingReceived` and `auto_answer` is enabled (and Do Not Disturb is not active), a single-shot timer is scheduled on the GUI thread. When it fires, the first still-pending incoming call is accepted through the same path used by the existing headset-button answer feature (`CallGui` + `Utils::openCallsWindow` + `lAccept`), so the calls window opens and account/video/recording parameters behave exactly like a manual accept. If the caller hung up before the delay elapsed, nothing happens (a warning is logged).

The config read follows the same pattern as the existing `command_line` feature handled in the same code block.

## Testing

Built on macOS 26.5 (Apple Silicon, Qt 6.10.2) and verified with real SIP calls over sip.linphone.org: an Android Linphone 6.2.3 device called the patched desktop app; the desktop rang for the configured 2000 ms, then auto-accepted and established two-way audio. Verified the call is *not* auto-accepted when `auto_answer=0`, when DND is enabled, or when the caller hangs up before the delay expires.

I am happy to sign the CLA and to re-submit this on gitlab.linphone.org if that is the preferred contribution channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)