### PR TITLE
Add BLF dialog-info presence monitoring and vCard file import

### DIFF
--- a/Linphone/core/friend/FriendCore.cpp
+++ b/Linphone/core/friend/FriendCore.cpp
@@ -19,7 +19,10 @@
  */
 
 #include "FriendCore.hpp"
+#include <QRegularExpression>
+
 #include "core/App.hpp"
+#include "model/setting/SettingsModel.hpp"
 #include "model/tool/ToolModel.hpp"
 #include "tool/Utils.hpp"
 #include "tool/thread/SafeConnection.hpp"
@@ -47,7 +50,7 @@ FriendCore::FriendCore(const std::shared_ptr<linphone::Friend> &contact, bool is
 	if (contact) {
 		mustBeInLinphoneThread(getClassName());
 		mFriendModel = Utils::makeQObject_ptr<FriendModel>(contact);
-		mFriendModel->setSelf(mFriendModel);
+		mFriendModel->setSelf(mFriendModel); // BLF auto-resubscribe happens here, once the SafeConnection is wired.
 		auto presence = mFriendModel->getPresence(contact);
 		auto note = mFriendModel->getPresenceNote(contact);
 		App::postCoreAsync([this, presence, note]() { setPresence(presence, note); });
@@ -210,10 +213,43 @@ void FriendCore::setSelf(QSharedPointer<FriendCore> me) {
 			mFriendModelConnection->makeConnectToModel(
 			    &FriendModel::objectNameChanged,
 			    [this](const QString &objectName) { lDebug() << "object name changed" << objectName; });
-
+			mFriendModelConnection->makeConnectToModel(&FriendModel::dialogStateChanged,
+			                                           [this](DialogInfoModel::State state) {
+				                                           QColor color;
+				                                           switch (state) {
+					                                           case DialogInfoModel::State::InCall:
+						                                           color = QColor(Qt::red);
+						                                           break;
+					                                           case DialogInfoModel::State::Ringing:
+						                                           color = QColor(255, 165, 0); // orange
+						                                           break;
+					                                           case DialogInfoModel::State::Idle:
+						                                           color = QColor(Qt::green);
+						                                           break;
+					                                           default:
+						                                           color = QColor(Qt::gray);
+						                                           break;
+				                                           }
+				                                           mFriendModelConnection->invokeToCore([this, color]() {
+					                                           mDialogStateColor = color;
+					                                           emit dialogStateChanged();
+				                                           });
+			                                           });
+			mFriendModelConnection->makeConnectToModel(&FriendModel::dialogMonitoringEnabledChanged,
+			                                           [this](bool enabled) {
+				                                           mFriendModelConnection->invokeToCore([this, enabled]() {
+					                                           mDialogMonitoringEnabled = enabled;
+					                                           emit dialogMonitoringEnabledChanged();
+				                                           });
+			                                           });
 			// From GUI
 			mFriendModelConnection->makeConnectToCore(&FriendCore::lSetStarred, [this](bool starred) {
 				mFriendModelConnection->invokeToModel([this, starred]() { mFriendModel->setStarred(starred); });
+			});
+			mFriendModelConnection->makeConnectToCore(&FriendCore::lToggleDialogMonitoring, [this]() {
+				mFriendModelConnection->invokeToModel([this]() {
+					mFriendModel->setDialogMonitoringEnabled(!mFriendModel->getDialogMonitoringEnabled());
+				});
 			});
 			if (!mCoreModelConnection) {
 				mCoreModelConnection = SafeConnection<FriendCore, CoreModel>::create(me, CoreModel::getInstance());
@@ -239,7 +275,18 @@ void FriendCore::setSelf(QSharedPointer<FriendCore> me) {
 			    });
 			mCoreModelConnection->makeConnectToCore(&FriendCore::saved, [this]() {
 				mCoreModelConnection->invokeToModel(
-				    [this, f = mFriendModel->getFriend()]() { emit CoreModel::getInstance()->friendUpdated(f); });
+				    [this, f = mFriendModel->getFriend()]() { emit CoreModel::getInstance() -> friendUpdated(f); });
+			});
+
+			// BLF: re-establish monitoring for contacts previously opted in, now that the SafeConnection is wired.
+			mFriendModelConnection->invokeToModel([this]() {
+				if (mFriendModel->getDialogMonitoringEnabled()) return;
+				auto address =
+				    mFriendModel->getFriend() && mFriendModel->getFriend()->getAddress()
+				        ? Utils::coreStringToAppString(mFriendModel->getFriend()->getAddress()->asStringUriOnly())
+				        : QString();
+				if (!address.isEmpty() && SettingsModel::getInstance()->getBlfMonitoredAddresses().contains(address))
+					mFriendModel->subscribeDialogInfo();
 			});
 
 		} else { // Create
@@ -667,7 +714,7 @@ void FriendCore::save() { // Save Values to model
 						thisCopy->writeIntoModel(mFriendModel);
 						thisCopy->deleteLater();
 						mVCardString = mFriendModel->getVCardAsString();
-						emit CoreModel::getInstance()->friendUpdated(contact);
+						emit CoreModel::getInstance() -> friendUpdated(contact);
 						mCoreModelConnection->invokeToCore([this] {
 							setIsSaved(true);
 							emit saved();
@@ -694,7 +741,7 @@ void FriendCore::save() { // Save Values to model
 							if (listWhereToAddFriend->getType() == linphone::FriendList::Type::CardDAV) {
 								listWhereToAddFriend->synchronizeFriendsFromServer();
 							}
-							emit CoreModel::getInstance()->friendCreated(contact);
+							emit CoreModel::getInstance() -> friendCreated(contact);
 						}
 						mCoreModelConnection->invokeToCore([this, created]() {
 							if (created) setSelf(mCoreModelConnection->mCore);
@@ -767,4 +814,22 @@ QColor FriendCore::getPresenceColor() {
 
 QString FriendCore::getPresenceStatus() {
 	return Utils::getPresenceStatus(mPresence);
+}
+
+void FriendCore::toggleDialogMonitoring() {
+	emit lToggleDialogMonitoring();
+}
+
+QColor FriendCore::getDialogStateColor() const {
+	return mDialogStateColor;
+}
+
+bool FriendCore::getDialogMonitoringEnabled() const {
+	return mDialogMonitoringEnabled;
+}
+
+bool FriendCore::getLooksLikeSipExtension() const {
+	static const QRegularExpression sipUserRegex(R"(^sips?:(\d+)@)");
+	auto match = sipUserRegex.match(mDefaultAddress);
+	return match.hasMatch();
 }

--- a/Linphone/core/friend/FriendCore.hpp
+++ b/Linphone/core/friend/FriendCore.hpp
@@ -76,6 +76,9 @@ class FriendCore : public QObject, public AbstractObject {
 	Q_PROPERTY(bool isLdap READ isLdap CONSTANT)
 	Q_PROPERTY(bool isAppFriend READ isAppFriend CONSTANT)
 	Q_PROPERTY(bool isCardDAV READ isCardDAV CONSTANT)
+	Q_PROPERTY(QColor dialogStateColor READ getDialogStateColor NOTIFY dialogStateChanged)
+	Q_PROPERTY(bool dialogMonitoringEnabled READ getDialogMonitoringEnabled NOTIFY dialogMonitoringEnabledChanged)
+	Q_PROPERTY(bool looksLikeSipExtension READ getLooksLikeSipExtension CONSTANT)
 
 public:
 	// Should be call from model Thread. Will be automatically in App thread after initialization
@@ -157,6 +160,18 @@ public:
 	QString getPresenceStatus();
 	QUrl getPresenceIcon();
 
+	// BLF ("dialog" event package): watches the friend's default address for
+	// live busy/ringing/idle state, driven by Asterisk/MikoPBX hint NOTIFYs
+	// rather than the (unpopulated, for internal extensions) presence package.
+	Q_INVOKABLE void toggleDialogMonitoring();
+	QColor getDialogStateColor() const;
+	bool getDialogMonitoringEnabled() const;
+	// Heuristic used to only offer BLF monitoring where it makes sense: an
+	// internal PBX extension (all-digits SIP username), not an arbitrary
+	// external contact - subscribing to "dialog" on those either gets
+	// rejected or silently does nothing useful.
+	bool getLooksLikeSipExtension() const;
+
 protected:
 	void resetPhoneNumbers(QList<QVariant> newList);
 	void resetAddresses(QList<QVariant> newList);
@@ -183,6 +198,9 @@ signals:
 	void verifiedDevicesChanged();
 	void lSetStarred(bool starred);
 	void presenceChanged();
+	void dialogStateChanged();
+	void dialogMonitoringEnabledChanged();
+	void lToggleDialogMonitoring();
 
 protected:
 	void writeIntoModel(std::shared_ptr<FriendModel> model) const;
@@ -209,6 +227,8 @@ protected:
 	bool mIsStored;
 	QString mVCardString;
 	bool mIsLdap, mIsCardDAV, mIsAppFriend;
+	QColor mDialogStateColor;
+	bool mDialogMonitoringEnabled = false;
 	std::shared_ptr<FriendModel> mFriendModel;
 	QSharedPointer<SafeConnection<FriendCore, FriendModel>> mFriendModelConnection;
 	QSharedPointer<SafeConnection<FriendCore, CoreModel>> mCoreModelConnection;

--- a/Linphone/data/languages/en.ts
+++ b/Linphone/data/languages/en.ts
@@ -3165,6 +3165,24 @@ Only your correspondent can decrypt them.</translation>
 <context>
     <name>ContactPage</name>
     <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="268"/>
+        <source>import_contacts_accessible_name</source>
+        <extracomment>Import contacts from a vCard file</extracomment>
+        <translation>Import contacts</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="305"/>
+        <source>information_popup_vcard_import_success_message</source>
+        <extracomment>&quot;Contacts importés&quot;</extracomment>
+        <translation>%1 contact(s) imported</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="310"/>
+        <source>information_popup_vcard_import_error_message</source>
+        <extracomment>&quot;Aucun contact n&apos;a pu être importé depuis ce fichier.&quot;</extracomment>
+        <translation>No contacts could be imported from this file.</translation>
+    </message>
+    <message>
         <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="16"/>
         <source>contacts_add</source>
         <extracomment>&quot;Ajouter un contact&quot;</extracomment>
@@ -3458,6 +3476,11 @@ You are about to call &quot;%1&quot; do you want to continue?</translation>
         <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="872"/>
         <source>information_popup_error_title</source>
         <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="304"/>
+        <source>information_popup_success_title</source>
+        <translation>Success</translation>
     </message>
     <message>
         <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="874"/>

--- a/Linphone/model/CMakeLists.txt
+++ b/Linphone/model/CMakeLists.txt
@@ -27,6 +27,7 @@ list(APPEND _LINPHONEAPP_SOURCES
 	model/core/CoreModel.cpp
 	
 	model/friend/FriendModel.cpp
+	model/friend/DialogInfoModel.cpp
 	model/friend/FriendsManager.cpp
 
 	model/listener/Listener.hpp

--- a/Linphone/model/friend/DialogInfoModel.cpp
+++ b/Linphone/model/friend/DialogInfoModel.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010-2024 Belledonne Communications SARL.
+ *
+ * This file is part of linphone-desktop
+ * (see https://www.linphone.org).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "DialogInfoModel.hpp"
+
+#include <QXmlStreamReader>
+
+DialogInfoModel::State DialogInfoModel::parse(const QString &xmlBody) {
+	QXmlStreamReader reader(xmlBody);
+
+	// A hint can aggregate several devices; report the busiest state found.
+	State worst = State::Unknown;
+
+	auto upgrade = [&worst](State candidate) {
+		// Priority: InCall > Ringing > Idle > Unknown
+		static auto rank = [](State s) {
+			switch (s) {
+				case State::InCall:
+					return 3;
+				case State::Ringing:
+					return 2;
+				case State::Idle:
+					return 1;
+				default:
+					return 0;
+			}
+		};
+		if (rank(candidate) > rank(worst)) worst = candidate;
+	};
+
+	bool sawDialogElement = false;
+
+	while (!reader.atEnd() && !reader.hasError()) {
+		auto token = reader.readNext();
+		if (token != QXmlStreamReader::StartElement) continue;
+
+		if (reader.name() == QLatin1String("dialog")) {
+			sawDialogElement = true;
+		} else if (reader.name() == QLatin1String("state") && sawDialogElement) {
+			auto stateText = reader.readElementText().trimmed();
+			if (stateText == QLatin1String("confirmed")) upgrade(State::InCall);
+			else if (stateText == QLatin1String("early")) upgrade(State::Ringing);
+			else if (stateText == QLatin1String("terminated")) upgrade(State::Idle);
+		}
+	}
+
+	if (reader.hasError()) return State::Unknown;
+
+	// No <dialog> element at all => extension has no active call => idle.
+	if (!sawDialogElement) return State::Idle;
+
+	return worst == State::Unknown ? State::Idle : worst;
+}

--- a/Linphone/model/friend/DialogInfoModel.hpp
+++ b/Linphone/model/friend/DialogInfoModel.hpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2024 Belledonne Communications SARL.
+ *
+ * This file is part of linphone-desktop
+ * (see https://www.linphone.org).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DIALOG_INFO_MODEL_H_
+#define DIALOG_INFO_MODEL_H_
+
+#include <QMetaType>
+#include <QString>
+
+// Parses "application/dialog-info+xml" NOTIFY bodies (RFC 4235), as sent by Asterisk/MikoPBX for BLF subscriptions.
+class DialogInfoModel {
+public:
+	enum class State {
+		Unknown, // Could not parse, or no <dialog> element present
+		Idle,    // No active dialog => extension is free
+		Ringing, // <state>early</state> => extension is ringing
+		InCall   // <state>confirmed</state> => extension is busy/on a call
+	};
+
+	// Returns Unknown if the body isn't well-formed dialog-info+xml.
+	static State parse(const QString &xmlBody);
+
+	static bool isBusy(State state) {
+		return state == State::InCall;
+	}
+};
+
+// Not a QObject enum, so it needs this to cross the model->UI queued connection (see SafeConnection).
+Q_DECLARE_METATYPE(DialogInfoModel::State)
+
+#endif

--- a/Linphone/model/friend/FriendModel.cpp
+++ b/Linphone/model/friend/FriendModel.cpp
@@ -61,10 +61,28 @@ FriendModel::FriendModel(const std::shared_ptr<linphone::Friend> &contact, const
 
 	connect(CoreModel::getInstance().get(), &CoreModel::friendUpdated, this, &FriendModel::onUpdated);
 	connect(CoreModel::getInstance().get(), &CoreModel::friendRemoved, this, &FriendModel::onRemoved);
+
+	// subscribeDialogInfo() itself is called later from FriendCore's ctor, once shared_from_this() is valid.
+	if (contact->getAddress()) {
+		auto address = Utils::coreStringToAppString(contact->getAddress()->asStringUriOnly());
+		mDialogMonitoringWanted = SettingsModel::getInstance()->getBlfMonitoredAddresses().contains(address);
+	}
+	// liblinphone doesn't recreate a dropped dialog-info SUBSCRIBE on reconnect the way it does for registration.
+	connect(CoreModel::getInstance().get(), &CoreModel::accountRegistrationStateChanged, this,
+	        [this](const std::shared_ptr<linphone::Core> &, const std::shared_ptr<linphone::Account> &,
+	               linphone::RegistrationState state, const std::string &) {
+		        if (state == linphone::RegistrationState::Ok && mDialogMonitoringWanted && !mDialogEvent) {
+			        lInfo() << log().arg("re-subscribing dialog-info for")
+			                << (mMonitor && mMonitor->getAddress() ? mMonitor->getAddress()->asStringUriOnly() : "?")
+			                << "after account came back online";
+			        subscribeDialogInfo();
+		        }
+	        });
 };
 
 FriendModel::~FriendModel() {
 	mustBeInLinphoneThread("~" + getClassName());
+	unsubscribeDialogInfo();
 	mMonitor = nullptr;
 }
 
@@ -321,6 +339,101 @@ LinphoneEnums::Presence FriendModel::getPresence(const std::shared_ptr<linphone:
 	return ToolModel::corePresenceModelToAppPresence(presenceModel);
 }
 
+//--------------------------------------------------------------------------------
+// BLF ("dialog" event package - RFC 4235)
+//--------------------------------------------------------------------------------
+
+void FriendModel::subscribeDialogInfo() {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	unsubscribeDialogInfo();
+	if (!mMonitor || !mMonitor->getAddress()) return;
+
+	auto core = CoreModel::getInstance()->getCore();
+	if (!core) return;
+
+	constexpr int dialogSubscribeExpiresSeconds = 120;
+	mDialogEvent = core->createSubscribe(mMonitor->getAddress()->clone(), "dialog", dialogSubscribeExpiresSeconds);
+	if (!mDialogEvent) {
+		lWarning() << log().arg("could not create dialog-info subscribe for")
+		           << mMonitor->getAddress()->asStringUriOnly();
+		return;
+	}
+	mDialogEvent->addListener(shared_from_this());
+	auto status = mDialogEvent->sendSubscribe(nullptr); // Empty body: pure watcher.
+	if (status != 0) {
+		lWarning() << log().arg("dialog-info SUBSCRIBE failed synchronously for")
+		           << mMonitor->getAddress()->asStringUriOnly();
+		mDialogEvent.reset();
+	}
+	emit dialogMonitoringEnabledChanged(mDialogEvent != nullptr);
+}
+
+void FriendModel::setDialogMonitoringEnabled(bool enabled) {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	mDialogMonitoringWanted = enabled;
+	if (mMonitor && mMonitor->getAddress()) {
+		auto address = Utils::coreStringToAppString(mMonitor->getAddress()->asStringUriOnly());
+		auto settings = SettingsModel::getInstance();
+		auto monitored = settings->getBlfMonitoredAddresses();
+		bool changed = false;
+		if (enabled && !monitored.contains(address)) {
+			monitored << address;
+			changed = true;
+		} else if (!enabled && monitored.removeAll(address) > 0) {
+			changed = true;
+		}
+		if (changed) settings->setBlfMonitoredAddresses(monitored);
+	}
+	if (enabled) subscribeDialogInfo();
+	else unsubscribeDialogInfo();
+}
+
+void FriendModel::unsubscribeDialogInfo() {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	bool wasEnabled = mDialogEvent != nullptr;
+	if (mDialogEvent) {
+		mDialogEvent->terminate();
+		mDialogEvent.reset();
+	}
+	if (wasEnabled) emit dialogMonitoringEnabledChanged(false);
+	if (mDialogState != DialogInfoModel::State::Unknown) {
+		mDialogState = DialogInfoModel::State::Unknown;
+		emit dialogStateChanged(mDialogState);
+	}
+}
+
+void FriendModel::onNotifyReceived(const std::shared_ptr<linphone::Event> &linphoneEvent,
+                                   const std::shared_ptr<const linphone::Content> &body) {
+	if (linphoneEvent != mDialogEvent) return; // Not for us (Friend also gets generic notifies)
+	if (!body) return;
+
+	// TODO: verify content type is application/dialog-info+xml before parsing.
+	auto xml = Utils::coreStringToAppString(body->getUtf8Text());
+	auto newState = DialogInfoModel::parse(xml);
+	if (newState == mDialogState) return;
+
+	lInfo() << log().arg("dialog-info state changed for")
+	        << (mMonitor && mMonitor->getAddress() ? mMonitor->getAddress()->asStringUriOnly() : "?") << "->"
+	        << static_cast<int>(newState);
+	mDialogState = newState;
+	emit dialogStateChanged(mDialogState);
+}
+
+void FriendModel::onSubscribeStateChanged(const std::shared_ptr<linphone::Event> &linphoneEvent,
+                                          linphone::SubscriptionState state) {
+	if (linphoneEvent != mDialogEvent) return;
+	if (state == linphone::SubscriptionState::Error || state == linphone::SubscriptionState::Terminated) {
+		// Fall back to Unknown rather than silently pretending the colleague is idle forever.
+		lWarning() << log().arg("dialog-info subscription ended, state=") << static_cast<int>(state);
+		mDialogEvent.reset();
+		emit dialogMonitoringEnabledChanged(false);
+		if (mDialogState != DialogInfoModel::State::Unknown) {
+			mDialogState = DialogInfoModel::State::Unknown;
+			emit dialogStateChanged(mDialogState);
+		}
+	}
+}
+
 QString FriendModel::getPresenceNote(const std::shared_ptr<linphone::Friend> &contact) {
 	auto presenceModel = contact->getPresenceModel();
 	auto note = presenceModel && presenceModel->getNote(Utils::appStringToCoreString(QLocale().name().left(2)))
@@ -404,7 +517,7 @@ void FriendModel::remove() {
 	}
 	auto temp = mMonitor;
 	temp->remove(); // mMonitor become null
-	emit CoreModel::getInstance()->friendRemoved(temp);
+	emit CoreModel::getInstance() -> friendRemoved(temp);
 }
 
 void FriendModel::onUpdated(const std::shared_ptr<linphone::Friend> &data) {

--- a/Linphone/model/friend/FriendModel.hpp
+++ b/Linphone/model/friend/FriendModel.hpp
@@ -21,6 +21,7 @@
 #ifndef FRIEND_MODEL_H_
 #define FRIEND_MODEL_H_
 
+#include "model/friend/DialogInfoModel.hpp"
 #include "model/listener/Listener.hpp"
 #include "tool/AbstractObject.hpp"
 #include "tool/LinphoneEnums.hpp"
@@ -30,9 +31,13 @@
 #include <QTimer>
 #include <linphone++/linphone.hh>
 
+// BLF: independent "dialog" event package (RFC 4235) subscription alongside the regular presence one, since
+// Asterisk/MikoPBX don't populate presence for internal extensions but do publish dialplan hints via dialog-info.
 class FriendModel : public ::Listener<linphone::Friend, linphone::FriendListener>,
                     public linphone::FriendListener,
-                    public AbstractObject {
+                    public linphone::EventListener,
+                    public AbstractObject,
+                    public std::enable_shared_from_this<FriendModel> {
 	Q_OBJECT
 	friend class FriendCore;
 
@@ -93,9 +98,25 @@ public:
 
 	LinphoneEnums::Presence getPresence(const std::shared_ptr<linphone::Friend> &contact);
 
+	// Safe to call multiple times; terminates a pre-existing subscription first.
+	void subscribeDialogInfo();
+	void unsubscribeDialogInfo();
+	DialogInfoModel::State getDialogState() const {
+		return mDialogState;
+	}
+	bool getDialogMonitoringEnabled() const {
+		return mDialogEvent != nullptr;
+	}
+
+	// Persists the intent and starts/stops the live subscription; also re-applied on reconnect (see
+	// mDialogMonitoringWanted).
+	void setDialogMonitoringEnabled(bool enabled);
+
 	QString mFullName;
 
 signals:
+	void dialogStateChanged(DialogInfoModel::State state);
+	void dialogMonitoringEnabledChanged(bool enabled);
 	void pictureUriChanged(const QString &uri);
 	void starredChanged(bool starred);
 	void addressesChanged();
@@ -119,6 +140,17 @@ private:
 	// LINPHONE
 	//--------------------------------------------------------------------------------
 	virtual void onPresenceReceived(const std::shared_ptr<linphone::Friend> &contact) override;
+
+	// linphone::EventListener - BLF "dialog" event package.
+	virtual void onNotifyReceived(const std::shared_ptr<linphone::Event> &linphoneEvent,
+	                              const std::shared_ptr<const linphone::Content> &body) override;
+	virtual void onSubscribeStateChanged(const std::shared_ptr<linphone::Event> &linphoneEvent,
+	                                     linphone::SubscriptionState state) override;
+
+	std::shared_ptr<linphone::Event> mDialogEvent;
+	DialogInfoModel::State mDialogState = DialogInfoModel::State::Unknown;
+	// Persisted intent, independent of mDialogEvent's live/dead state.
+	bool mDialogMonitoringWanted = false;
 };
 
 #endif

--- a/Linphone/model/setting/SettingsModel.cpp
+++ b/Linphone/model/setting/SettingsModel.cpp
@@ -418,6 +418,23 @@ void SettingsModel::setCreateEndToEndEncryptedMeetingsAndGroupCalls(bool endtoen
 	emit createEndToEndEncryptedMeetingsAndGroupCallsChanged(endtoend);
 }
 
+QStringList SettingsModel::getBlfMonitoredAddresses() const {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	auto list = mConfig->getStringList(SettingsModel::AppSection, "blf_monitored_addresses", {});
+	QStringList result;
+	for (auto &address : list)
+		result << Utils::coreStringToAppString(address);
+	return result;
+}
+
+void SettingsModel::setBlfMonitoredAddresses(const QStringList &addresses) {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	std::list<std::string> list;
+	for (auto &address : addresses)
+		list.push_back(Utils::appStringToCoreString(address));
+	mConfig->setStringList(SettingsModel::AppSection, "blf_monitored_addresses", list);
+}
+
 // -----------------------------------------------------------------------------
 
 QVariantMap SettingsModel::getPlaybackDevice() const {

--- a/Linphone/model/setting/SettingsModel.hpp
+++ b/Linphone/model/setting/SettingsModel.hpp
@@ -25,6 +25,7 @@
 #include "tool/LinphoneEnums.hpp"
 #include <QFont>
 #include <QObject>
+#include <QStringList>
 #include <QVariantMap>
 #include <linphone++/linphone.hh>
 
@@ -56,6 +57,10 @@ public:
 
 	bool getVideoEnabled() const;
 	void setVideoEnabled(const bool enabled);
+
+	// SIP URIs of friends opted into BLF ("dialog" event package) monitoring.
+	QStringList getBlfMonitoredAddresses() const;
+	void setBlfMonitoredAddresses(const QStringList &addresses);
 
 	bool getAutomaticallyRecordCallsEnabled() const;
 	void setAutomaticallyRecordCallsEnabled(bool enabled);

--- a/Linphone/tool/Utils.cpp
+++ b/Linphone/tool/Utils.cpp
@@ -57,6 +57,7 @@
 #include <QQuickWindow>
 #include <QRandomGenerator>
 #include <QRegularExpression>
+#include <QSet>
 #include <QStandardPaths>
 #include <QSvgRenderer>
 
@@ -623,6 +624,33 @@ QString Utils::createVCardFile(const QString &username, const QString &vcardAsSt
 		return filepath;
 	}
 	return QString();
+}
+
+VariantObject *Utils::importVCardFile(const QUrl &fileUrl) {
+	if (!App::getInstance()->getCoreStarted()) return nullptr;
+	QString path = fileUrl.toLocalFile();
+	VariantObject *result = new VariantObject("importVCardFile");
+	if (!result) return nullptr;
+	result->makeRequest([path]() {
+		// Model thread.
+		if (path.isEmpty()) return QVariant(-1);
+		auto friendList = ToolModel::getAppFriendList();
+		if (!friendList) return QVariant(-1);
+		QSet<const void *> before;
+		for (auto &f : friendList->getFriends())
+			before.insert(f.get());
+		int imported = friendList->importFriendsFromVcard4File(path.toStdString());
+		if (imported > 0) {
+			// importFriendsFromVcard4File() only adds to the SDK-side list; the
+			// app UI (MagicSearchList) only refreshes off friendCreated, same as
+			// every other "friend appeared" path in this app.
+			for (auto &f : friendList->getFriends())
+				if (!before.contains(f.get())) emit CoreModel::getInstance() -> friendCreated(f);
+		}
+		return QVariant(imported);
+	});
+	result->requestValue();
+	return result;
 }
 
 void Utils::shareByEmail(const QString &subject,

--- a/Linphone/tool/Utils.hpp
+++ b/Linphone/tool/Utils.hpp
@@ -25,6 +25,7 @@
 #include <QObject>
 #include <QSize>
 #include <QString>
+#include <QUrl>
 
 #include "Constants.hpp"
 #include "tool/AbstractObject.hpp"
@@ -104,6 +105,11 @@ public:
 	Q_INVOKABLE static int getRandomIndex(int size);
 	Q_INVOKABLE static bool copyToClipboard(const QString &text);
 	Q_INVOKABLE static QString createVCardFile(const QString &username, const QString &vcardAsString);
+	// Bulk contact import: parses every vCard in the given file and adds each
+	// as a Friend to the app's contact list. Runs on the linphone thread;
+	// the returned VariantObject's `value` becomes the imported count once
+	// ready (0 or -1 on failure/bad path).
+	Q_INVOKABLE static VariantObject *importVCardFile(const QUrl &fileUrl);
 	Q_INVOKABLE static void shareByEmail(const QString &subject,
 	                                     const QString &body = QString(),
 	                                     const QString &attachment = QString(),

--- a/Linphone/view/Control/Display/Contact/ContactListItem.qml
+++ b/Linphone/view/Control/Display/Contact/ContactListItem.qml
@@ -73,12 +73,27 @@ FocusScope {
             anchors.bottom: parent.bottom
             spacing: Utils.getSizeWithScreenRatio(16)
             z: contactArea.z + 1
-            Avatar {
+            Item {
                 Layout.preferredWidth: Utils.getSizeWithScreenRatio(45)
                 Layout.preferredHeight: Utils.getSizeWithScreenRatio(45)
                 Layout.leftMargin: Utils.getSizeWithScreenRatio(5)
-                contact: searchResultItem
-                shadowEnabled: false
+                Avatar {
+                    anchors.fill: parent
+                    contact: searchResultItem
+                    shadowEnabled: false
+                }
+                // BLF (Busy Lamp Field) indicator: idle/ringing/busy, driven by dialog-info NOTIFYs.
+                Rectangle {
+                    visible: searchResultItem.core.dialogMonitoringEnabled
+                    width: Utils.getSizeWithScreenRatio(13)
+                    height: width
+                    radius: width / 2
+                    color: searchResultItem.core.dialogStateColor
+                    border.color: DefaultStyle.main2_0
+                    border.width: Utils.getSizeWithScreenRatio(2)
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                }
             }
             ColumnLayout {
                 spacing: 0
@@ -222,6 +237,20 @@ FocusScope {
                             onClicked: {
                                 searchResultItem.core.lSetStarred(
                                             !searchResultItem.core.starred)
+                                friendPopup.close()
+                            }
+                            style: ButtonStyle.noBackground
+                        }
+                        IconLabelButton {
+                            Layout.fillWidth: true
+                            visible: searchResultItem && searchResultItem.core.looksLikeSipExtension
+                            text: searchResultItem.core.dialogMonitoringEnabled ? qsTr("Arrêter le suivi BLF")
+                                                                                : qsTr("Suivre l'état (BLF)")
+                            icon.source: AppIcons.phone
+                            spacing: Utils.getSizeWithScreenRatio(10)
+                            textColor: DefaultStyle.main2_500_main
+                            onClicked: {
+                                searchResultItem.core.toggleDialogMonitoring()
                                 friendPopup.close()
                             }
                             style: ButtonStyle.noBackground

--- a/Linphone/view/Page/Main/Contact/ContactPage.qml
+++ b/Linphone/view/Page/Main/Contact/ContactPage.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Dialogs
 import QtQuick.Effects
 import QtQuick.Layouts
 import QtQuick.Controls.Basic as Control
@@ -253,6 +254,20 @@ AbstractMainPage {
                 font.weight: Typography.h2.weight
             }
             Button {
+                id: importContactsButton
+                visible: !rightPanelStackView.currentItem
+                         || rightPanelStackView.currentItem.objectName !== "contactEdition"
+                style: ButtonStyle.noBackground
+                icon.source: AppIcons.filePlus
+                Layout.preferredWidth: Utils.getSizeWithScreenRatio(28)
+                Layout.preferredHeight: Utils.getSizeWithScreenRatio(28)
+                icon.width: Utils.getSizeWithScreenRatio(28)
+                icon.height: Utils.getSizeWithScreenRatio(28)
+                onClicked: importVCardDialog.open()
+                //: Import contacts from a vCard file
+                Accessible.name: qsTr("import_contacts_accessible_name")
+            }
+            Button {
                 id: createContactButton
                 visible: !rightPanelStackView.currentItem
                          || rightPanelStackView.currentItem.objectName !== "contactEdition"
@@ -269,6 +284,33 @@ AbstractMainPage {
                 KeyNavigation.down: searchBar
                 //: Create new contact
                 Accessible.name: qsTr("create_contact_accessible_name")
+            }
+        }
+
+        FileDialog {
+            id: importVCardDialog
+            nameFilters: ["vCard files (*.vcf)"]
+            onAccepted: {
+                var request = UtilsCpp.importVCardFile(selectedFile)
+                if (request) importVCardResult.target = request
+            }
+        }
+        Connections {
+            id: importVCardResult
+            function onValueChanged() {
+                var count = target.value
+                if (count > 0) {
+                    //: "Contacts importés"
+                    UtilsCpp.showInformationPopup(qsTr("information_popup_success_title"),
+                                                  qsTr("information_popup_vcard_import_success_message").arg(count),
+                                                  true)
+                } else {
+                    //: "Aucun contact n'a pu être importé depuis ce fichier."
+                    UtilsCpp.showInformationPopup(qsTr("information_popup_error_title"),
+                                                  qsTr("information_popup_vcard_import_error_message"),
+                                                  false)
+                }
+                target = null
             }
         }
 


### PR DESCRIPTION
## Summary

- Adds BLF-style presence for internal PBX extensions via SIP `dialog-info` (RFC 4235) subscription, distinguishing In-Call / Ringing / Idle states for contacts.
- Adds a generic vCard-file contact import (Contacts page: pick a `.vcf` file, imports all entries via the existing `importFriendsFromVcard4File` friend-list API).

Both features are vendor-neutral and standards-based — no dependency on any specific PBX vendor's API. See [#1006](https://github.com/BelledonneCommunications/linphone-desktop/issues/1006) for background/discussion on this and a related (out-of-scope) MikoPBX-specific registration-status overlay.

## Test plan

- [x] Built on Windows (MSVC/Qt6/Ninja) against current `master` + synced `linphone-sdk` submodule, 702/702 targets, no errors
- [x] Verified `linphone.exe` launches and stays running (no crash) after the change
- [ ] Manual verification of dialog-info state transitions (In-Call/Ringing/Idle) against a live PBX — done in my own environment against MikoPBX; happy to expand test coverage if maintainers want it in a specific form
- [ ] Manual verification of vCard import against a `.vcf` file with multiple entries
