### PR TITLE
Add optional MikoPBX-specific registration-status overlay and extension import

### DIFF
--- a/Linphone/core/friend/FriendCore.cpp
+++ b/Linphone/core/friend/FriendCore.cpp
@@ -242,6 +242,14 @@ void FriendCore::setSelf(QSharedPointer<FriendCore> me) {
 					                                           emit dialogMonitoringEnabledChanged();
 				                                           });
 			                                           });
+			mFriendModelConnection->makeConnectToModel(&FriendModel::isOnlineChanged, [this](bool online) {
+				mFriendModelConnection->invokeToCore([this, online]() {
+					mIsOnline = online;
+					emit isOnlineChanged();
+					emit dialogStateChanged(); // getDialogStateColor() also depends on mIsOnline.
+				});
+			});
+
 			// From GUI
 			mFriendModelConnection->makeConnectToCore(&FriendCore::lSetStarred, [this](bool starred) {
 				mFriendModelConnection->invokeToModel([this, starred]() { mFriendModel->setStarred(starred); });
@@ -821,7 +829,13 @@ void FriendCore::toggleDialogMonitoring() {
 }
 
 QColor FriendCore::getDialogStateColor() const {
+	// Offline always wins: dialog-info alone can't distinguish idle from unregistered.
+	if (!mIsOnline) return QColor(Qt::gray);
 	return mDialogStateColor;
+}
+
+bool FriendCore::getIsOnline() const {
+	return mIsOnline;
 }
 
 bool FriendCore::getDialogMonitoringEnabled() const {

--- a/Linphone/core/friend/FriendCore.cpp
+++ b/Linphone/core/friend/FriendCore.cpp
@@ -19,7 +19,10 @@
  */
 
 #include "FriendCore.hpp"
+#include <QRegularExpression>
+
 #include "core/App.hpp"
+#include "model/setting/SettingsModel.hpp"
 #include "model/tool/ToolModel.hpp"
 #include "tool/Utils.hpp"
 #include "tool/thread/SafeConnection.hpp"
@@ -47,7 +50,7 @@ FriendCore::FriendCore(const std::shared_ptr<linphone::Friend> &contact, bool is
 	if (contact) {
 		mustBeInLinphoneThread(getClassName());
 		mFriendModel = Utils::makeQObject_ptr<FriendModel>(contact);
-		mFriendModel->setSelf(mFriendModel);
+		mFriendModel->setSelf(mFriendModel); // BLF auto-resubscribe happens here, once the SafeConnection is wired.
 		auto presence = mFriendModel->getPresence(contact);
 		auto note = mFriendModel->getPresenceNote(contact);
 		App::postCoreAsync([this, presence, note]() { setPresence(presence, note); });
@@ -210,10 +213,43 @@ void FriendCore::setSelf(QSharedPointer<FriendCore> me) {
 			mFriendModelConnection->makeConnectToModel(
 			    &FriendModel::objectNameChanged,
 			    [this](const QString &objectName) { lDebug() << "object name changed" << objectName; });
-
+			mFriendModelConnection->makeConnectToModel(&FriendModel::dialogStateChanged,
+			                                           [this](DialogInfoModel::State state) {
+				                                           QColor color;
+				                                           switch (state) {
+					                                           case DialogInfoModel::State::InCall:
+						                                           color = QColor(Qt::red);
+						                                           break;
+					                                           case DialogInfoModel::State::Ringing:
+						                                           color = QColor(255, 165, 0); // orange
+						                                           break;
+					                                           case DialogInfoModel::State::Idle:
+						                                           color = QColor(Qt::green);
+						                                           break;
+					                                           default:
+						                                           color = QColor(Qt::gray);
+						                                           break;
+				                                           }
+				                                           mFriendModelConnection->invokeToCore([this, color]() {
+					                                           mDialogStateColor = color;
+					                                           emit dialogStateChanged();
+				                                           });
+			                                           });
+			mFriendModelConnection->makeConnectToModel(&FriendModel::dialogMonitoringEnabledChanged,
+			                                           [this](bool enabled) {
+				                                           mFriendModelConnection->invokeToCore([this, enabled]() {
+					                                           mDialogMonitoringEnabled = enabled;
+					                                           emit dialogMonitoringEnabledChanged();
+				                                           });
+			                                           });
 			// From GUI
 			mFriendModelConnection->makeConnectToCore(&FriendCore::lSetStarred, [this](bool starred) {
 				mFriendModelConnection->invokeToModel([this, starred]() { mFriendModel->setStarred(starred); });
+			});
+			mFriendModelConnection->makeConnectToCore(&FriendCore::lToggleDialogMonitoring, [this]() {
+				mFriendModelConnection->invokeToModel([this]() {
+					mFriendModel->setDialogMonitoringEnabled(!mFriendModel->getDialogMonitoringEnabled());
+				});
 			});
 			if (!mCoreModelConnection) {
 				mCoreModelConnection = SafeConnection<FriendCore, CoreModel>::create(me, CoreModel::getInstance());
@@ -239,7 +275,18 @@ void FriendCore::setSelf(QSharedPointer<FriendCore> me) {
 			    });
 			mCoreModelConnection->makeConnectToCore(&FriendCore::saved, [this]() {
 				mCoreModelConnection->invokeToModel(
-				    [this, f = mFriendModel->getFriend()]() { emit CoreModel::getInstance()->friendUpdated(f); });
+				    [this, f = mFriendModel->getFriend()]() { emit CoreModel::getInstance() -> friendUpdated(f); });
+			});
+
+			// BLF: re-establish monitoring for contacts previously opted in, now that the SafeConnection is wired.
+			mFriendModelConnection->invokeToModel([this]() {
+				if (mFriendModel->getDialogMonitoringEnabled()) return;
+				auto address =
+				    mFriendModel->getFriend() && mFriendModel->getFriend()->getAddress()
+				        ? Utils::coreStringToAppString(mFriendModel->getFriend()->getAddress()->asStringUriOnly())
+				        : QString();
+				if (!address.isEmpty() && SettingsModel::getInstance()->getBlfMonitoredAddresses().contains(address))
+					mFriendModel->subscribeDialogInfo();
 			});
 
 		} else { // Create
@@ -667,7 +714,7 @@ void FriendCore::save() { // Save Values to model
 						thisCopy->writeIntoModel(mFriendModel);
 						thisCopy->deleteLater();
 						mVCardString = mFriendModel->getVCardAsString();
-						emit CoreModel::getInstance()->friendUpdated(contact);
+						emit CoreModel::getInstance() -> friendUpdated(contact);
 						mCoreModelConnection->invokeToCore([this] {
 							setIsSaved(true);
 							emit saved();
@@ -694,7 +741,7 @@ void FriendCore::save() { // Save Values to model
 							if (listWhereToAddFriend->getType() == linphone::FriendList::Type::CardDAV) {
 								listWhereToAddFriend->synchronizeFriendsFromServer();
 							}
-							emit CoreModel::getInstance()->friendCreated(contact);
+							emit CoreModel::getInstance() -> friendCreated(contact);
 						}
 						mCoreModelConnection->invokeToCore([this, created]() {
 							if (created) setSelf(mCoreModelConnection->mCore);
@@ -767,4 +814,22 @@ QColor FriendCore::getPresenceColor() {
 
 QString FriendCore::getPresenceStatus() {
 	return Utils::getPresenceStatus(mPresence);
+}
+
+void FriendCore::toggleDialogMonitoring() {
+	emit lToggleDialogMonitoring();
+}
+
+QColor FriendCore::getDialogStateColor() const {
+	return mDialogStateColor;
+}
+
+bool FriendCore::getDialogMonitoringEnabled() const {
+	return mDialogMonitoringEnabled;
+}
+
+bool FriendCore::getLooksLikeSipExtension() const {
+	static const QRegularExpression sipUserRegex(R"(^sips?:(\d+)@)");
+	auto match = sipUserRegex.match(mDefaultAddress);
+	return match.hasMatch();
 }

--- a/Linphone/core/friend/FriendCore.hpp
+++ b/Linphone/core/friend/FriendCore.hpp
@@ -76,6 +76,9 @@ class FriendCore : public QObject, public AbstractObject {
 	Q_PROPERTY(bool isLdap READ isLdap CONSTANT)
 	Q_PROPERTY(bool isAppFriend READ isAppFriend CONSTANT)
 	Q_PROPERTY(bool isCardDAV READ isCardDAV CONSTANT)
+	Q_PROPERTY(QColor dialogStateColor READ getDialogStateColor NOTIFY dialogStateChanged)
+	Q_PROPERTY(bool dialogMonitoringEnabled READ getDialogMonitoringEnabled NOTIFY dialogMonitoringEnabledChanged)
+	Q_PROPERTY(bool looksLikeSipExtension READ getLooksLikeSipExtension CONSTANT)
 
 public:
 	// Should be call from model Thread. Will be automatically in App thread after initialization
@@ -157,6 +160,18 @@ public:
 	QString getPresenceStatus();
 	QUrl getPresenceIcon();
 
+	// BLF ("dialog" event package): watches the friend's default address for
+	// live busy/ringing/idle state, driven by Asterisk/MikoPBX hint NOTIFYs
+	// rather than the (unpopulated, for internal extensions) presence package.
+	Q_INVOKABLE void toggleDialogMonitoring();
+	QColor getDialogStateColor() const;
+	bool getDialogMonitoringEnabled() const;
+	// Heuristic used to only offer BLF monitoring where it makes sense: an
+	// internal PBX extension (all-digits SIP username), not an arbitrary
+	// external contact - subscribing to "dialog" on those either gets
+	// rejected or silently does nothing useful.
+	bool getLooksLikeSipExtension() const;
+
 protected:
 	void resetPhoneNumbers(QList<QVariant> newList);
 	void resetAddresses(QList<QVariant> newList);
@@ -183,6 +198,9 @@ signals:
 	void verifiedDevicesChanged();
 	void lSetStarred(bool starred);
 	void presenceChanged();
+	void dialogStateChanged();
+	void dialogMonitoringEnabledChanged();
+	void lToggleDialogMonitoring();
 
 protected:
 	void writeIntoModel(std::shared_ptr<FriendModel> model) const;
@@ -209,6 +227,8 @@ protected:
 	bool mIsStored;
 	QString mVCardString;
 	bool mIsLdap, mIsCardDAV, mIsAppFriend;
+	QColor mDialogStateColor;
+	bool mDialogMonitoringEnabled = false;
 	std::shared_ptr<FriendModel> mFriendModel;
 	QSharedPointer<SafeConnection<FriendCore, FriendModel>> mFriendModelConnection;
 	QSharedPointer<SafeConnection<FriendCore, CoreModel>> mCoreModelConnection;

--- a/Linphone/core/friend/FriendCore.hpp
+++ b/Linphone/core/friend/FriendCore.hpp
@@ -79,6 +79,7 @@ class FriendCore : public QObject, public AbstractObject {
 	Q_PROPERTY(QColor dialogStateColor READ getDialogStateColor NOTIFY dialogStateChanged)
 	Q_PROPERTY(bool dialogMonitoringEnabled READ getDialogMonitoringEnabled NOTIFY dialogMonitoringEnabledChanged)
 	Q_PROPERTY(bool looksLikeSipExtension READ getLooksLikeSipExtension CONSTANT)
+	Q_PROPERTY(bool isOnline READ getIsOnline NOTIFY isOnlineChanged)
 
 public:
 	// Should be call from model Thread. Will be automatically in App thread after initialization
@@ -160,17 +161,14 @@ public:
 	QString getPresenceStatus();
 	QUrl getPresenceIcon();
 
-	// BLF ("dialog" event package): watches the friend's default address for
-	// live busy/ringing/idle state, driven by Asterisk/MikoPBX hint NOTIFYs
-	// rather than the (unpopulated, for internal extensions) presence package.
+	// BLF ("dialog" event package): live busy/ringing/idle state via Asterisk/MikoPBX hint NOTIFYs.
 	Q_INVOKABLE void toggleDialogMonitoring();
 	QColor getDialogStateColor() const;
 	bool getDialogMonitoringEnabled() const;
-	// Heuristic used to only offer BLF monitoring where it makes sense: an
-	// internal PBX extension (all-digits SIP username), not an arbitrary
-	// external contact - subscribing to "dialog" on those either gets
-	// rejected or silently does nothing useful.
+	// Only offer BLF monitoring for internal PBX extensions (all-digits SIP username).
 	bool getLooksLikeSipExtension() const;
+	// Real registration status (MikoPBX REST API polling); defaults to true when unconfigured.
+	bool getIsOnline() const;
 
 protected:
 	void resetPhoneNumbers(QList<QVariant> newList);
@@ -201,6 +199,7 @@ signals:
 	void dialogStateChanged();
 	void dialogMonitoringEnabledChanged();
 	void lToggleDialogMonitoring();
+	void isOnlineChanged();
 
 protected:
 	void writeIntoModel(std::shared_ptr<FriendModel> model) const;
@@ -229,6 +228,7 @@ protected:
 	bool mIsLdap, mIsCardDAV, mIsAppFriend;
 	QColor mDialogStateColor;
 	bool mDialogMonitoringEnabled = false;
+	bool mIsOnline = true;
 	std::shared_ptr<FriendModel> mFriendModel;
 	QSharedPointer<SafeConnection<FriendCore, FriendModel>> mFriendModelConnection;
 	QSharedPointer<SafeConnection<FriendCore, CoreModel>> mCoreModelConnection;

--- a/Linphone/core/setting/SettingsCore.cpp
+++ b/Linphone/core/setting/SettingsCore.cpp
@@ -146,6 +146,8 @@ SettingsCore::SettingsCore(QObject *parent) : QObject(parent) {
 	INIT_CORE_MEMBER(AssistantGoDirectlyToThirdPartySipAccountLogin, settingsModel)
 	INIT_CORE_MEMBER(AssistantThirdPartySipAccountDomain, settingsModel)
 	INIT_CORE_MEMBER(AssistantThirdPartySipAccountTransport, settingsModel)
+	INIT_CORE_MEMBER(PbxApiBaseUrl, settingsModel)
+	INIT_CORE_MEMBER(PbxApiKey, settingsModel)
 	INIT_CORE_MEMBER(AutoStart, settingsModel)
 	INIT_CORE_MEMBER(ExitOnClose, settingsModel)
 	INIT_CORE_MEMBER(SyncLdapContacts, settingsModel)
@@ -233,6 +235,8 @@ SettingsCore::SettingsCore(const SettingsCore &settingsCore) {
 	mAssistantGoDirectlyToThirdPartySipAccountLogin = settingsCore.mAssistantGoDirectlyToThirdPartySipAccountLogin;
 	mAssistantThirdPartySipAccountDomain = settingsCore.mAssistantThirdPartySipAccountDomain;
 	mAssistantThirdPartySipAccountTransport = settingsCore.mAssistantThirdPartySipAccountTransport;
+	mPbxApiBaseUrl = settingsCore.mPbxApiBaseUrl;
+	mPbxApiKey = settingsCore.mPbxApiKey;
 	mExitOnClose = settingsCore.mExitOnClose;
 	mSyncLdapContacts = settingsCore.mSyncLdapContacts;
 	mIpv6Enabled = settingsCore.mIpv6Enabled;
@@ -357,6 +361,8 @@ void SettingsCore::reloadSettings() {
 	    settingsModel->getAssistantGoDirectlyToThirdPartySipAccountLogin());
 	setAssistantThirdPartySipAccountDomain(settingsModel->getAssistantThirdPartySipAccountDomain());
 	setAssistantThirdPartySipAccountTransport(settingsModel->getAssistantThirdPartySipAccountTransport());
+	setPbxApiBaseUrl(settingsModel->getPbxApiBaseUrl());
+	setPbxApiKey(settingsModel->getPbxApiKey());
 	setAutoStart(settingsModel->getAutoStart());
 	setExitOnClose(settingsModel->getExitOnClose());
 	setSyncLdapContacts(settingsModel->getSyncLdapContacts());
@@ -658,6 +664,10 @@ void SettingsCore::setSelf(QSharedPointer<SettingsCore> me) {
 	                           assistantThirdPartySipAccountDomain, AssistantThirdPartySipAccountDomain)
 	DEFINE_CORE_GETSET_CONNECT(mSettingsModelConnection, SettingsCore, SettingsModel, settingsModel, QString,
 	                           assistantThirdPartySipAccountTransport, AssistantThirdPartySipAccountTransport)
+	DEFINE_CORE_GETSET_CONNECT(mSettingsModelConnection, SettingsCore, SettingsModel, settingsModel, QString,
+	                           pbxApiBaseUrl, PbxApiBaseUrl)
+	DEFINE_CORE_GETSET_CONNECT(mSettingsModelConnection, SettingsCore, SettingsModel, settingsModel, QString, pbxApiKey,
+	                           PbxApiKey)
 	DEFINE_CORE_GET_CONNECT(mSettingsModelConnection, SettingsCore, SettingsModel, settingsModel, bool, autoStart,
 	                        AutoStart)
 	DEFINE_CORE_GETSET_CONNECT(mSettingsModelConnection, SettingsCore, SettingsModel, settingsModel, bool, exitOnClose,
@@ -775,6 +785,8 @@ void SettingsCore::reset(const SettingsCore &settingsCore) {
 	setAssistantGoDirectlyToThirdPartySipAccountLogin(settingsCore.mAssistantGoDirectlyToThirdPartySipAccountLogin);
 	setAssistantThirdPartySipAccountDomain(settingsCore.mAssistantThirdPartySipAccountDomain);
 	setAssistantThirdPartySipAccountTransport(settingsCore.mAssistantThirdPartySipAccountTransport);
+	setPbxApiBaseUrl(settingsCore.mPbxApiBaseUrl);
+	setPbxApiKey(settingsCore.mPbxApiKey);
 	setExitOnClose(settingsCore.mExitOnClose);
 	setSyncLdapContacts(settingsCore.mSyncLdapContacts);
 	setCardDAVMinCharForResearch(settingsCore.mCardDAVMinCharForResearch);
@@ -1448,6 +1460,8 @@ void SettingsCore::writeIntoModel(std::shared_ptr<SettingsModel> model) const {
 	model->setAssistantGoDirectlyToThirdPartySipAccountLogin(mAssistantGoDirectlyToThirdPartySipAccountLogin);
 	model->setAssistantThirdPartySipAccountDomain(mAssistantThirdPartySipAccountDomain);
 	model->setAssistantThirdPartySipAccountTransport(mAssistantThirdPartySipAccountTransport);
+	model->setPbxApiBaseUrl(mPbxApiBaseUrl);
+	model->setPbxApiKey(mPbxApiKey);
 	model->setExitOnClose(mExitOnClose);
 	model->setSyncLdapContacts(mSyncLdapContacts);
 	model->setIpv6Enabled(mIpv6Enabled);
@@ -1539,6 +1553,8 @@ void SettingsCore::writeFromModel(const std::shared_ptr<SettingsModel> &model) {
 	mAssistantGoDirectlyToThirdPartySipAccountLogin = model->getAssistantGoDirectlyToThirdPartySipAccountLogin();
 	mAssistantThirdPartySipAccountDomain = model->getAssistantThirdPartySipAccountDomain();
 	mAssistantThirdPartySipAccountTransport = model->getAssistantThirdPartySipAccountTransport();
+	mPbxApiBaseUrl = model->getPbxApiBaseUrl();
+	mPbxApiKey = model->getPbxApiKey();
 	mAutoStart = model->getAutoStart();
 	mExitOnClose = model->getExitOnClose();
 	mSyncLdapContacts = model->getSyncLdapContacts();

--- a/Linphone/core/setting/SettingsCore.hpp
+++ b/Linphone/core/setting/SettingsCore.hpp
@@ -335,6 +335,9 @@ public:
 	                           AssistantGoDirectlyToThirdPartySipAccountLogin)
 	DECLARE_CORE_GETSET_MEMBER(QString, assistantThirdPartySipAccountDomain, AssistantThirdPartySipAccountDomain)
 	DECLARE_CORE_GETSET_MEMBER(QString, assistantThirdPartySipAccountTransport, AssistantThirdPartySipAccountTransport)
+	// Used by both the BLF presence poll and the "import extensions" contact bulk-add.
+	DECLARE_CORE_GETSET_MEMBER(QString, pbxApiBaseUrl, PbxApiBaseUrl)
+	DECLARE_CORE_GETSET_MEMBER(QString, pbxApiKey, PbxApiKey)
 	DECLARE_CORE_GETSET(bool, exitOnClose, ExitOnClose)
 	DECLARE_CORE_GETSET(bool, syncLdapContacts, SyncLdapContacts)
 	DECLARE_CORE_GETSET(QString, configLocale, ConfigLocale)

--- a/Linphone/data/languages/en.ts
+++ b/Linphone/data/languages/en.ts
@@ -3165,6 +3165,24 @@ Only your correspondent can decrypt them.</translation>
 <context>
     <name>ContactPage</name>
     <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="268"/>
+        <source>import_contacts_accessible_name</source>
+        <extracomment>Import contacts from a vCard file</extracomment>
+        <translation>Import contacts</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="305"/>
+        <source>information_popup_vcard_import_success_message</source>
+        <extracomment>&quot;Contacts importés&quot;</extracomment>
+        <translation>%1 contact(s) imported</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="310"/>
+        <source>information_popup_vcard_import_error_message</source>
+        <extracomment>&quot;Aucun contact n&apos;a pu être importé depuis ce fichier.&quot;</extracomment>
+        <translation>No contacts could be imported from this file.</translation>
+    </message>
+    <message>
         <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="16"/>
         <source>contacts_add</source>
         <extracomment>&quot;Ajouter un contact&quot;</extracomment>
@@ -3458,6 +3476,11 @@ You are about to call &quot;%1&quot; do you want to continue?</translation>
         <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="872"/>
         <source>information_popup_error_title</source>
         <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="304"/>
+        <source>information_popup_success_title</source>
+        <translation>Success</translation>
     </message>
     <message>
         <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="874"/>

--- a/Linphone/data/languages/en.ts
+++ b/Linphone/data/languages/en.ts
@@ -994,6 +994,27 @@
     </message>
 </context>
 <context>
+    <name>PbxSettingsLayout</name>
+    <message>
+        <location filename="../../view/Page/Layout/Settings/PbxSettingsLayout.qml" line="30"/>
+        <source>settings_pbx_description</source>
+        <extracomment>&quot;Utilisé pour le statut BLF en ligne/hors ligne et l&apos;import des interlocuteurs&quot;</extracomment>
+        <translation>Used for BLF online/offline status and importing contacts.</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Layout/Settings/PbxSettingsLayout.qml" line="43"/>
+        <source>settings_pbx_base_url_title</source>
+        <extracomment>&quot;URL du PBX&quot;</extracomment>
+        <translation>PBX URL</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Layout/Settings/PbxSettingsLayout.qml" line="52"/>
+        <source>settings_pbx_api_key_title</source>
+        <extracomment>&quot;Clé API&quot;</extracomment>
+        <translation>API key</translation>
+    </message>
+</context>
+<context>
     <name>CallHistoryLayout</name>
     <message>
         <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="116"/>
@@ -3169,6 +3190,12 @@ Only your correspondent can decrypt them.</translation>
         <source>import_contacts_accessible_name</source>
         <extracomment>Import contacts from a vCard file</extracomment>
         <translation>Import contacts</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="285"/>
+        <source>import_contacts_from_pbx_accessible_name</source>
+        <extracomment>Import contacts from the PBX extension list</extracomment>
+        <translation>Import contacts from PBX</translation>
     </message>
     <message>
         <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="305"/>
@@ -6637,6 +6664,12 @@ To enable them in a commercial project, please contact us.</translation>
         <source>settings_advanced_title</source>
         <extracomment>&quot;Paramètres avancés&quot;</extracomment>
         <translation>Advanced parameters</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="33"/>
+        <source>settings_pbx_title</source>
+        <extracomment>&quot;Intégration PBX&quot;</extracomment>
+        <translation>PBX integration</translation>
     </message>
     <message>
         <source>contact_editor_popup_abort_confirmation_title</source>

--- a/Linphone/model/CMakeLists.txt
+++ b/Linphone/model/CMakeLists.txt
@@ -27,6 +27,7 @@ list(APPEND _LINPHONEAPP_SOURCES
 	model/core/CoreModel.cpp
 	
 	model/friend/FriendModel.cpp
+	model/friend/DialogInfoModel.cpp
 	model/friend/FriendsManager.cpp
 
 	model/listener/Listener.hpp

--- a/Linphone/model/core/CoreModel.cpp
+++ b/Linphone/model/core/CoreModel.cpp
@@ -24,14 +24,22 @@
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkReply>
 #include <QQuickWindow>
+#include <QRegularExpression>
+#include <QSet>
 #include <QSysInfo>
+#include <QTemporaryFile>
 #include <QTimer>
 
 #include "core/App.hpp"
 #include "core/notifier/Notifier.hpp"
 #include "core/path/Paths.hpp"
 #include "model/call/CallModel.hpp"
+#include "model/setting/SettingsModel.hpp"
 #include "model/tool/ToolModel.hpp"
 #include "tool/Utils.hpp"
 
@@ -118,9 +126,131 @@ void CoreModel::start() {
 	mMagicSearch->setSelf(mMagicSearch);
 	connect(mMagicSearch.get(), &MagicSearchModel::searchResultsReceived, this,
 	        [this] { emit magicSearchResultReceived(mMagicSearch->mLastSearch); });
+
+	mPresenceNetworkManager = new QNetworkAccessManager(this);
+	mPresenceTimer = new QTimer(this);
+	mPresenceTimer->setInterval(30000);
+	connect(mPresenceTimer, &QTimer::timeout, this, &CoreModel::pollExtensionPresence);
+	mPresenceTimer->start();
+	// Deferred: SettingsModel isn't created yet at this point on cold startup, so pollExtensionPresence() would no-op.
+	QTimer::singleShot(0, this, &CoreModel::pollExtensionPresence);
+
 	mStarted = true;
 }
 // -----------------------------------------------------------------------------
+
+void CoreModel::pollExtensionPresence() {
+	auto settings = SettingsModel::getInstance();
+	if (!settings) return;
+	auto baseUrl = settings->getPbxApiBaseUrl();
+	auto apiKey = settings->getPbxApiKey();
+	if (baseUrl.isEmpty() || apiKey.isEmpty()) return;
+
+	static const QRegularExpression sipUserRegex(R"(^sips?:(\d+)@)");
+	QSet<QString> extensions;
+	for (auto &address : settings->getBlfMonitoredAddresses()) {
+		auto match = sipUserRegex.match(address);
+		if (match.hasMatch()) extensions.insert(match.captured(1));
+	}
+
+	for (auto &extension : extensions) {
+		QUrl url(baseUrl + "/pbxcore/api/v3/sip/" + extension + ":getStatus");
+		QNetworkRequest request(url);
+		request.setRawHeader("Authorization", ("Bearer " + apiKey).toUtf8());
+		auto reply = mPresenceNetworkManager->get(request);
+		connect(reply, &QNetworkReply::finished, this, [this, reply, extension]() {
+			reply->deleteLater();
+			if (reply->error() != QNetworkReply::NoError) {
+				lWarning()
+				    << log().arg("Presence poll for extension %1 failed: %2").arg(extension).arg(reply->errorString());
+				return;
+			}
+			auto doc = QJsonDocument::fromJson(reply->readAll());
+			bool online = doc["data"]["devices"].toArray().size() > 0; // "status" field is unreliable; devices[] isn't.
+			lInfo()
+			    << log().arg("Presence poll for extension %1: %2").arg(extension).arg(online ? "online" : "offline");
+			emit extensionPresenceChanged(extension, online);
+		});
+	}
+}
+
+void CoreModel::importExtensionsFromPbx() {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	auto settings = SettingsModel::getInstance();
+	if (!settings) {
+		emit extensionsImportFromPbxFinished(0, "not ready");
+		return;
+	}
+	auto baseUrl = settings->getPbxApiBaseUrl();
+	auto apiKey = settings->getPbxApiKey();
+	if (baseUrl.isEmpty() || apiKey.isEmpty()) {
+		emit extensionsImportFromPbxFinished(0, "MikoPBX API not configured");
+		return;
+	}
+
+	QUrl url(baseUrl + "/pbxcore/api/v3/extensions");
+	QNetworkRequest request(url);
+	request.setRawHeader("Authorization", ("Bearer " + apiKey).toUtf8());
+	auto reply = mPresenceNetworkManager->get(request);
+	QString host = QUrl(baseUrl).host();
+	connect(reply, &QNetworkReply::finished, this, [this, reply, host]() {
+		reply->deleteLater();
+		if (reply->error() != QNetworkReply::NoError) {
+			lWarning() << log().arg("Extensions import failed: %1").arg(reply->errorString());
+			emit extensionsImportFromPbxFinished(0, reply->errorString());
+			return;
+		}
+		auto doc = QJsonDocument::fromJson(reply->readAll());
+		auto entries = doc["data"].toArray();
+
+		// Queues, IVRs, parking slots etc. share the same list but aren't people to call.
+		QString vcard;
+		int candidateCount = 0;
+		for (const auto &entryRef : qAsConst(entries)) {
+			auto entry = entryRef.toObject();
+			if (entry["type"].toString() != "SIP") continue;
+			auto number = entry["number"].toString();
+			if (number.isEmpty()) continue;
+			auto name = entry["callerid"].toString();
+			if (name.isEmpty()) name = number;
+			candidateCount++;
+			vcard += "BEGIN:VCARD\r\nVERSION:4.0\r\nFN:" + name + "\r\nIMPP:sip:" + number + "@" + host +
+			         "\r\nEND:VCARD\r\n";
+		}
+		if (candidateCount == 0) {
+			emit extensionsImportFromPbxFinished(0, "no SIP extensions found");
+			return;
+		}
+
+		auto friendList = ToolModel::getAppFriendList();
+		if (!friendList) {
+			emit extensionsImportFromPbxFinished(0, "contact list not ready");
+			return;
+		}
+		QSet<const void *> before;
+		for (auto &f : friendList->getFriends())
+			before.insert(f.get());
+
+		QTemporaryFile file(QDir::temp().filePath("pbx_extensions_XXXXXX.vcf"));
+		if (!file.open()) {
+			emit extensionsImportFromPbxFinished(0, "could not write temporary file");
+			return;
+		}
+		file.write(vcard.toUtf8());
+		file.close();
+
+		int imported = friendList->importFriendsFromVcard4File(file.fileName().toStdString());
+		if (imported > 0) {
+			for (auto &f : friendList->getFriends())
+				if (!before.contains(f.get())) emit friendCreated(f);
+		}
+		lInfo() << log()
+		               .arg("Extensions import: %1 SIP extensions found, %2 new contacts created")
+		               .arg(candidateCount)
+		               .arg(imported);
+		emit extensionsImportFromPbxFinished(imported, "");
+	});
+}
 
 bool CoreModel::isInitialized() const {
 	return mStarted;

--- a/Linphone/model/core/CoreModel.hpp
+++ b/Linphone/model/core/CoreModel.hpp
@@ -22,6 +22,7 @@
 #define CORE_MODEL_H_
 
 #include <QMap>
+#include <QNetworkAccessManager>
 #include <QObject>
 #include <QSharedPointer>
 #include <QString>
@@ -60,6 +61,9 @@ public:
 	void start();
 	void setConfigPath(QString path);
 	void setPathsAfterCreation();
+
+	// Imports every SIP-type extension from MikoPBX's REST API as a contact. No-ops (with an error) if unconfigured.
+	void importExtensionsFromPbx();
 
 	void refreshOidcRemainingTime();
 
@@ -112,9 +116,13 @@ private:
 	std::shared_ptr<MagicSearchModel> mMagicSearch;
 	bool mStarted = false;
 	bool mCheckVersionRequestedByUser = false;
+	QTimer *mPresenceTimer = nullptr;
+	QNetworkAccessManager *mPresenceNetworkManager = nullptr;
 
 	void setPathBeforeCreation();
 	void setPathAfterStart();
+	// Polls MikoPBX for registration status of every BLF-monitored extension; no-ops if unconfigured.
+	void pollExtensionPresence();
 
 	static std::shared_ptr<CoreModel> gCoreModel;
 
@@ -229,6 +237,8 @@ signals:
 	                                     const std::shared_ptr<linphone::Account> &account,
 	                                     linphone::RegistrationState state,
 	                                     const std::string &message);
+	void extensionPresenceChanged(QString extension, bool online);     // extension is a SIP username, not the full URI.
+	void extensionsImportFromPbxFinished(int imported, QString error); // error is non-empty only on failure.
 	void authenticationRequested(const std::shared_ptr<linphone::Core> &core,
 	                             const std::shared_ptr<linphone::AuthInfo> &authInfo,
 	                             linphone::AuthMethod method);

--- a/Linphone/model/friend/DialogInfoModel.cpp
+++ b/Linphone/model/friend/DialogInfoModel.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2010-2024 Belledonne Communications SARL.
+ *
+ * This file is part of linphone-desktop
+ * (see https://www.linphone.org).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "DialogInfoModel.hpp"
+
+#include <QXmlStreamReader>
+
+DialogInfoModel::State DialogInfoModel::parse(const QString &xmlBody) {
+	QXmlStreamReader reader(xmlBody);
+
+	// A hint can aggregate several devices; report the busiest state found.
+	State worst = State::Unknown;
+
+	auto upgrade = [&worst](State candidate) {
+		// Priority: InCall > Ringing > Idle > Unknown
+		static auto rank = [](State s) {
+			switch (s) {
+				case State::InCall:
+					return 3;
+				case State::Ringing:
+					return 2;
+				case State::Idle:
+					return 1;
+				default:
+					return 0;
+			}
+		};
+		if (rank(candidate) > rank(worst)) worst = candidate;
+	};
+
+	bool sawDialogElement = false;
+
+	while (!reader.atEnd() && !reader.hasError()) {
+		auto token = reader.readNext();
+		if (token != QXmlStreamReader::StartElement) continue;
+
+		if (reader.name() == QLatin1String("dialog")) {
+			sawDialogElement = true;
+		} else if (reader.name() == QLatin1String("state") && sawDialogElement) {
+			auto stateText = reader.readElementText().trimmed();
+			if (stateText == QLatin1String("confirmed")) upgrade(State::InCall);
+			else if (stateText == QLatin1String("early")) upgrade(State::Ringing);
+			else if (stateText == QLatin1String("terminated")) upgrade(State::Idle);
+		}
+	}
+
+	if (reader.hasError()) return State::Unknown;
+
+	// No <dialog> element at all => extension has no active call => idle.
+	if (!sawDialogElement) return State::Idle;
+
+	return worst == State::Unknown ? State::Idle : worst;
+}

--- a/Linphone/model/friend/DialogInfoModel.hpp
+++ b/Linphone/model/friend/DialogInfoModel.hpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2024 Belledonne Communications SARL.
+ *
+ * This file is part of linphone-desktop
+ * (see https://www.linphone.org).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DIALOG_INFO_MODEL_H_
+#define DIALOG_INFO_MODEL_H_
+
+#include <QMetaType>
+#include <QString>
+
+// Parses "application/dialog-info+xml" NOTIFY bodies (RFC 4235), as sent by Asterisk/MikoPBX for BLF subscriptions.
+class DialogInfoModel {
+public:
+	enum class State {
+		Unknown, // Could not parse, or no <dialog> element present
+		Idle,    // No active dialog => extension is free
+		Ringing, // <state>early</state> => extension is ringing
+		InCall   // <state>confirmed</state> => extension is busy/on a call
+	};
+
+	// Returns Unknown if the body isn't well-formed dialog-info+xml.
+	static State parse(const QString &xmlBody);
+
+	static bool isBusy(State state) {
+		return state == State::InCall;
+	}
+};
+
+// Not a QObject enum, so it needs this to cross the model->UI queued connection (see SafeConnection).
+Q_DECLARE_METATYPE(DialogInfoModel::State)
+
+#endif

--- a/Linphone/model/friend/FriendModel.cpp
+++ b/Linphone/model/friend/FriendModel.cpp
@@ -61,10 +61,28 @@ FriendModel::FriendModel(const std::shared_ptr<linphone::Friend> &contact, const
 
 	connect(CoreModel::getInstance().get(), &CoreModel::friendUpdated, this, &FriendModel::onUpdated);
 	connect(CoreModel::getInstance().get(), &CoreModel::friendRemoved, this, &FriendModel::onRemoved);
+
+	// subscribeDialogInfo() itself is called later from FriendCore's ctor, once shared_from_this() is valid.
+	if (contact->getAddress()) {
+		auto address = Utils::coreStringToAppString(contact->getAddress()->asStringUriOnly());
+		mDialogMonitoringWanted = SettingsModel::getInstance()->getBlfMonitoredAddresses().contains(address);
+	}
+	// liblinphone doesn't recreate a dropped dialog-info SUBSCRIBE on reconnect the way it does for registration.
+	connect(CoreModel::getInstance().get(), &CoreModel::accountRegistrationStateChanged, this,
+	        [this](const std::shared_ptr<linphone::Core> &, const std::shared_ptr<linphone::Account> &,
+	               linphone::RegistrationState state, const std::string &) {
+		        if (state == linphone::RegistrationState::Ok && mDialogMonitoringWanted && !mDialogEvent) {
+			        lInfo() << log().arg("re-subscribing dialog-info for")
+			                << (mMonitor && mMonitor->getAddress() ? mMonitor->getAddress()->asStringUriOnly() : "?")
+			                << "after account came back online";
+			        subscribeDialogInfo();
+		        }
+	        });
 };
 
 FriendModel::~FriendModel() {
 	mustBeInLinphoneThread("~" + getClassName());
+	unsubscribeDialogInfo();
 	mMonitor = nullptr;
 }
 
@@ -321,6 +339,101 @@ LinphoneEnums::Presence FriendModel::getPresence(const std::shared_ptr<linphone:
 	return ToolModel::corePresenceModelToAppPresence(presenceModel);
 }
 
+//--------------------------------------------------------------------------------
+// BLF ("dialog" event package - RFC 4235)
+//--------------------------------------------------------------------------------
+
+void FriendModel::subscribeDialogInfo() {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	unsubscribeDialogInfo();
+	if (!mMonitor || !mMonitor->getAddress()) return;
+
+	auto core = CoreModel::getInstance()->getCore();
+	if (!core) return;
+
+	constexpr int dialogSubscribeExpiresSeconds = 120;
+	mDialogEvent = core->createSubscribe(mMonitor->getAddress()->clone(), "dialog", dialogSubscribeExpiresSeconds);
+	if (!mDialogEvent) {
+		lWarning() << log().arg("could not create dialog-info subscribe for")
+		           << mMonitor->getAddress()->asStringUriOnly();
+		return;
+	}
+	mDialogEvent->addListener(shared_from_this());
+	auto status = mDialogEvent->sendSubscribe(nullptr); // Empty body: pure watcher.
+	if (status != 0) {
+		lWarning() << log().arg("dialog-info SUBSCRIBE failed synchronously for")
+		           << mMonitor->getAddress()->asStringUriOnly();
+		mDialogEvent.reset();
+	}
+	emit dialogMonitoringEnabledChanged(mDialogEvent != nullptr);
+}
+
+void FriendModel::setDialogMonitoringEnabled(bool enabled) {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	mDialogMonitoringWanted = enabled;
+	if (mMonitor && mMonitor->getAddress()) {
+		auto address = Utils::coreStringToAppString(mMonitor->getAddress()->asStringUriOnly());
+		auto settings = SettingsModel::getInstance();
+		auto monitored = settings->getBlfMonitoredAddresses();
+		bool changed = false;
+		if (enabled && !monitored.contains(address)) {
+			monitored << address;
+			changed = true;
+		} else if (!enabled && monitored.removeAll(address) > 0) {
+			changed = true;
+		}
+		if (changed) settings->setBlfMonitoredAddresses(monitored);
+	}
+	if (enabled) subscribeDialogInfo();
+	else unsubscribeDialogInfo();
+}
+
+void FriendModel::unsubscribeDialogInfo() {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	bool wasEnabled = mDialogEvent != nullptr;
+	if (mDialogEvent) {
+		mDialogEvent->terminate();
+		mDialogEvent.reset();
+	}
+	if (wasEnabled) emit dialogMonitoringEnabledChanged(false);
+	if (mDialogState != DialogInfoModel::State::Unknown) {
+		mDialogState = DialogInfoModel::State::Unknown;
+		emit dialogStateChanged(mDialogState);
+	}
+}
+
+void FriendModel::onNotifyReceived(const std::shared_ptr<linphone::Event> &linphoneEvent,
+                                   const std::shared_ptr<const linphone::Content> &body) {
+	if (linphoneEvent != mDialogEvent) return; // Not for us (Friend also gets generic notifies)
+	if (!body) return;
+
+	// TODO: verify content type is application/dialog-info+xml before parsing.
+	auto xml = Utils::coreStringToAppString(body->getUtf8Text());
+	auto newState = DialogInfoModel::parse(xml);
+	if (newState == mDialogState) return;
+
+	lInfo() << log().arg("dialog-info state changed for")
+	        << (mMonitor && mMonitor->getAddress() ? mMonitor->getAddress()->asStringUriOnly() : "?") << "->"
+	        << static_cast<int>(newState);
+	mDialogState = newState;
+	emit dialogStateChanged(mDialogState);
+}
+
+void FriendModel::onSubscribeStateChanged(const std::shared_ptr<linphone::Event> &linphoneEvent,
+                                          linphone::SubscriptionState state) {
+	if (linphoneEvent != mDialogEvent) return;
+	if (state == linphone::SubscriptionState::Error || state == linphone::SubscriptionState::Terminated) {
+		// Fall back to Unknown rather than silently pretending the colleague is idle forever.
+		lWarning() << log().arg("dialog-info subscription ended, state=") << static_cast<int>(state);
+		mDialogEvent.reset();
+		emit dialogMonitoringEnabledChanged(false);
+		if (mDialogState != DialogInfoModel::State::Unknown) {
+			mDialogState = DialogInfoModel::State::Unknown;
+			emit dialogStateChanged(mDialogState);
+		}
+	}
+}
+
 QString FriendModel::getPresenceNote(const std::shared_ptr<linphone::Friend> &contact) {
 	auto presenceModel = contact->getPresenceModel();
 	auto note = presenceModel && presenceModel->getNote(Utils::appStringToCoreString(QLocale().name().left(2)))
@@ -404,7 +517,7 @@ void FriendModel::remove() {
 	}
 	auto temp = mMonitor;
 	temp->remove(); // mMonitor become null
-	emit CoreModel::getInstance()->friendRemoved(temp);
+	emit CoreModel::getInstance() -> friendRemoved(temp);
 }
 
 void FriendModel::onUpdated(const std::shared_ptr<linphone::Friend> &data) {

--- a/Linphone/model/friend/FriendModel.cpp
+++ b/Linphone/model/friend/FriendModel.cpp
@@ -78,6 +78,17 @@ FriendModel::FriendModel(const std::shared_ptr<linphone::Friend> &contact, const
 			        subscribeDialogInfo();
 		        }
 	        });
+
+	// Real registration status: dialog-info alone can't distinguish idle from unregistered.
+	connect(CoreModel::getInstance().get(), &CoreModel::extensionPresenceChanged, this,
+	        [this](QString extension, bool online) {
+		        if (!mMonitor || !mMonitor->getAddress()) return;
+		        auto ownExtension = Utils::coreStringToAppString(mMonitor->getAddress()->getUsername());
+		        if (ownExtension != extension || mIsOnline == online) return;
+		        mIsOnline = online;
+		        lInfo() << log().arg("isOnline for %1 changed to %2").arg(ownExtension).arg(online ? "true" : "false");
+		        emit isOnlineChanged(mIsOnline);
+	        });
 };
 
 FriendModel::~FriendModel() {

--- a/Linphone/model/friend/FriendModel.hpp
+++ b/Linphone/model/friend/FriendModel.hpp
@@ -21,6 +21,7 @@
 #ifndef FRIEND_MODEL_H_
 #define FRIEND_MODEL_H_
 
+#include "model/friend/DialogInfoModel.hpp"
 #include "model/listener/Listener.hpp"
 #include "tool/AbstractObject.hpp"
 #include "tool/LinphoneEnums.hpp"
@@ -30,9 +31,13 @@
 #include <QTimer>
 #include <linphone++/linphone.hh>
 
+// BLF: independent "dialog" event package (RFC 4235) subscription alongside the regular presence one, since
+// Asterisk/MikoPBX don't populate presence for internal extensions but do publish dialplan hints via dialog-info.
 class FriendModel : public ::Listener<linphone::Friend, linphone::FriendListener>,
                     public linphone::FriendListener,
-                    public AbstractObject {
+                    public linphone::EventListener,
+                    public AbstractObject,
+                    public std::enable_shared_from_this<FriendModel> {
 	Q_OBJECT
 	friend class FriendCore;
 
@@ -93,9 +98,25 @@ public:
 
 	LinphoneEnums::Presence getPresence(const std::shared_ptr<linphone::Friend> &contact);
 
+	// Safe to call multiple times; terminates a pre-existing subscription first.
+	void subscribeDialogInfo();
+	void unsubscribeDialogInfo();
+	DialogInfoModel::State getDialogState() const {
+		return mDialogState;
+	}
+	bool getDialogMonitoringEnabled() const {
+		return mDialogEvent != nullptr;
+	}
+
+	// Persists the intent and starts/stops the live subscription; also re-applied on reconnect (see
+	// mDialogMonitoringWanted).
+	void setDialogMonitoringEnabled(bool enabled);
+
 	QString mFullName;
 
 signals:
+	void dialogStateChanged(DialogInfoModel::State state);
+	void dialogMonitoringEnabledChanged(bool enabled);
 	void pictureUriChanged(const QString &uri);
 	void starredChanged(bool starred);
 	void addressesChanged();
@@ -119,6 +140,17 @@ private:
 	// LINPHONE
 	//--------------------------------------------------------------------------------
 	virtual void onPresenceReceived(const std::shared_ptr<linphone::Friend> &contact) override;
+
+	// linphone::EventListener - BLF "dialog" event package.
+	virtual void onNotifyReceived(const std::shared_ptr<linphone::Event> &linphoneEvent,
+	                              const std::shared_ptr<const linphone::Content> &body) override;
+	virtual void onSubscribeStateChanged(const std::shared_ptr<linphone::Event> &linphoneEvent,
+	                                     linphone::SubscriptionState state) override;
+
+	std::shared_ptr<linphone::Event> mDialogEvent;
+	DialogInfoModel::State mDialogState = DialogInfoModel::State::Unknown;
+	// Persisted intent, independent of mDialogEvent's live/dead state.
+	bool mDialogMonitoringWanted = false;
 };
 
 #endif

--- a/Linphone/model/friend/FriendModel.hpp
+++ b/Linphone/model/friend/FriendModel.hpp
@@ -108,15 +108,20 @@ public:
 		return mDialogEvent != nullptr;
 	}
 
-	// Persists the intent and starts/stops the live subscription; also re-applied on reconnect (see
-	// mDialogMonitoringWanted).
+	// Persists the intent and starts/stops the live subscription; also re-applied on reconnect.
 	void setDialogMonitoringEnabled(bool enabled);
+
+	// Real registration status (MikoPBX REST API polling); defaults to true when unconfigured.
+	bool getIsOnline() const {
+		return mIsOnline;
+	}
 
 	QString mFullName;
 
 signals:
 	void dialogStateChanged(DialogInfoModel::State state);
 	void dialogMonitoringEnabledChanged(bool enabled);
+	void isOnlineChanged(bool online);
 	void pictureUriChanged(const QString &uri);
 	void starredChanged(bool starred);
 	void addressesChanged();
@@ -151,6 +156,7 @@ private:
 	DialogInfoModel::State mDialogState = DialogInfoModel::State::Unknown;
 	// Persisted intent, independent of mDialogEvent's live/dead state.
 	bool mDialogMonitoringWanted = false;
+	bool mIsOnline = true;
 };
 
 #endif

--- a/Linphone/model/setting/SettingsModel.cpp
+++ b/Linphone/model/setting/SettingsModel.cpp
@@ -418,6 +418,23 @@ void SettingsModel::setCreateEndToEndEncryptedMeetingsAndGroupCalls(bool endtoen
 	emit createEndToEndEncryptedMeetingsAndGroupCallsChanged(endtoend);
 }
 
+QStringList SettingsModel::getBlfMonitoredAddresses() const {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	auto list = mConfig->getStringList(SettingsModel::AppSection, "blf_monitored_addresses", {});
+	QStringList result;
+	for (auto &address : list)
+		result << Utils::coreStringToAppString(address);
+	return result;
+}
+
+void SettingsModel::setBlfMonitoredAddresses(const QStringList &addresses) {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	std::list<std::string> list;
+	for (auto &address : addresses)
+		list.push_back(Utils::appStringToCoreString(address));
+	mConfig->setStringList(SettingsModel::AppSection, "blf_monitored_addresses", list);
+}
+
 // -----------------------------------------------------------------------------
 
 QVariantMap SettingsModel::getPlaybackDevice() const {

--- a/Linphone/model/setting/SettingsModel.cpp
+++ b/Linphone/model/setting/SettingsModel.cpp
@@ -435,6 +435,28 @@ void SettingsModel::setBlfMonitoredAddresses(const QStringList &addresses) {
 	mConfig->setStringList(SettingsModel::AppSection, "blf_monitored_addresses", list);
 }
 
+QString SettingsModel::getPbxApiBaseUrl() const {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	return Utils::coreStringToAppString(mConfig->getString(SettingsModel::AppSection, "pbx_api_base_url", ""));
+}
+
+void SettingsModel::setPbxApiBaseUrl(const QString &url) {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	mConfig->setString(SettingsModel::AppSection, "pbx_api_base_url", Utils::appStringToCoreString(url));
+	emit pbxApiBaseUrlChanged(url);
+}
+
+QString SettingsModel::getPbxApiKey() const {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	return Utils::coreStringToAppString(mConfig->getString(SettingsModel::AppSection, "pbx_api_key", ""));
+}
+
+void SettingsModel::setPbxApiKey(const QString &key) {
+	mustBeInLinphoneThread(log().arg(Q_FUNC_INFO));
+	mConfig->setString(SettingsModel::AppSection, "pbx_api_key", Utils::appStringToCoreString(key));
+	emit pbxApiKeyChanged(key);
+}
+
 // -----------------------------------------------------------------------------
 
 QVariantMap SettingsModel::getPlaybackDevice() const {

--- a/Linphone/model/setting/SettingsModel.hpp
+++ b/Linphone/model/setting/SettingsModel.hpp
@@ -25,6 +25,7 @@
 #include "tool/LinphoneEnums.hpp"
 #include <QFont>
 #include <QObject>
+#include <QStringList>
 #include <QVariantMap>
 #include <linphone++/linphone.hh>
 
@@ -56,6 +57,10 @@ public:
 
 	bool getVideoEnabled() const;
 	void setVideoEnabled(const bool enabled);
+
+	// SIP URIs of friends opted into BLF ("dialog" event package) monitoring.
+	QStringList getBlfMonitoredAddresses() const;
+	void setBlfMonitoredAddresses(const QStringList &addresses);
 
 	bool getAutomaticallyRecordCallsEnabled() const;
 	void setAutomaticallyRecordCallsEnabled(bool enabled);

--- a/Linphone/model/setting/SettingsModel.hpp
+++ b/Linphone/model/setting/SettingsModel.hpp
@@ -62,6 +62,12 @@ public:
 	QStringList getBlfMonitoredAddresses() const;
 	void setBlfMonitoredAddresses(const QStringList &addresses);
 
+	// MikoPBX REST API (read-only "sip" scope key), used to poll real registration status - see FriendModel::mIsOnline.
+	QString getPbxApiBaseUrl() const;
+	void setPbxApiBaseUrl(const QString &url);
+	QString getPbxApiKey() const;
+	void setPbxApiKey(const QString &key);
+
 	bool getAutomaticallyRecordCallsEnabled() const;
 	void setAutomaticallyRecordCallsEnabled(bool enabled);
 
@@ -259,6 +265,8 @@ public:
 
 signals:
 	void logsUploadUrlChanged();
+	void pbxApiBaseUrlChanged(const QString &url);
+	void pbxApiKeyChanged(const QString &key);
 
 	// VFS. --------------------------------------------------------------------
 	void vfsEnabledChanged(bool enabled);

--- a/Linphone/tool/Utils.cpp
+++ b/Linphone/tool/Utils.cpp
@@ -641,9 +641,7 @@ VariantObject *Utils::importVCardFile(const QUrl &fileUrl) {
 			before.insert(f.get());
 		int imported = friendList->importFriendsFromVcard4File(path.toStdString());
 		if (imported > 0) {
-			// importFriendsFromVcard4File() only adds to the SDK-side list; the
-			// app UI (MagicSearchList) only refreshes off friendCreated, same as
-			// every other "friend appeared" path in this app.
+			// The app UI only refreshes off friendCreated, so emit it for each newly imported friend.
 			for (auto &f : friendList->getFriends())
 				if (!before.contains(f.get())) emit CoreModel::getInstance() -> friendCreated(f);
 		}
@@ -651,6 +649,27 @@ VariantObject *Utils::importVCardFile(const QUrl &fileUrl) {
 	});
 	result->requestValue();
 	return result;
+}
+
+void Utils::importExtensionsFromPbx() {
+	if (!App::getInstance()->getCoreStarted()) return;
+	QMetaObject::invokeMethod(App::getInstance()->getLinphoneThread()->getThreadId(), [] {
+		connect(
+		    CoreModel::getInstance().get(), &CoreModel::extensionsImportFromPbxFinished, CoreModel::getInstance().get(),
+		    [](int imported, QString error) {
+			    auto window = App::getInstance()->getMainWindow();
+			    if (!error.isEmpty())
+				    QMetaObject::invokeMethod(window, "showInformationPopup", Q_ARG(QVariant, QString("Import failed")),
+				                              Q_ARG(QVariant, error), Q_ARG(QVariant, false));
+			    else
+				    QMetaObject::invokeMethod(
+				        window, "showInformationPopup", Q_ARG(QVariant, QString("Import complete")),
+				        Q_ARG(QVariant, QString("%1 contact(s) imported from MikoPBX").arg(imported)),
+				        Q_ARG(QVariant, true));
+		    },
+		    Qt::SingleShotConnection);
+		CoreModel::getInstance()->importExtensionsFromPbx();
+	});
 }
 
 void Utils::shareByEmail(const QString &subject,

--- a/Linphone/tool/Utils.cpp
+++ b/Linphone/tool/Utils.cpp
@@ -57,6 +57,7 @@
 #include <QQuickWindow>
 #include <QRandomGenerator>
 #include <QRegularExpression>
+#include <QSet>
 #include <QStandardPaths>
 #include <QSvgRenderer>
 
@@ -623,6 +624,33 @@ QString Utils::createVCardFile(const QString &username, const QString &vcardAsSt
 		return filepath;
 	}
 	return QString();
+}
+
+VariantObject *Utils::importVCardFile(const QUrl &fileUrl) {
+	if (!App::getInstance()->getCoreStarted()) return nullptr;
+	QString path = fileUrl.toLocalFile();
+	VariantObject *result = new VariantObject("importVCardFile");
+	if (!result) return nullptr;
+	result->makeRequest([path]() {
+		// Model thread.
+		if (path.isEmpty()) return QVariant(-1);
+		auto friendList = ToolModel::getAppFriendList();
+		if (!friendList) return QVariant(-1);
+		QSet<const void *> before;
+		for (auto &f : friendList->getFriends())
+			before.insert(f.get());
+		int imported = friendList->importFriendsFromVcard4File(path.toStdString());
+		if (imported > 0) {
+			// importFriendsFromVcard4File() only adds to the SDK-side list; the
+			// app UI (MagicSearchList) only refreshes off friendCreated, same as
+			// every other "friend appeared" path in this app.
+			for (auto &f : friendList->getFriends())
+				if (!before.contains(f.get())) emit CoreModel::getInstance() -> friendCreated(f);
+		}
+		return QVariant(imported);
+	});
+	result->requestValue();
+	return result;
 }
 
 void Utils::shareByEmail(const QString &subject,

--- a/Linphone/tool/Utils.hpp
+++ b/Linphone/tool/Utils.hpp
@@ -25,6 +25,7 @@
 #include <QObject>
 #include <QSize>
 #include <QString>
+#include <QUrl>
 
 #include "Constants.hpp"
 #include "tool/AbstractObject.hpp"
@@ -104,6 +105,11 @@ public:
 	Q_INVOKABLE static int getRandomIndex(int size);
 	Q_INVOKABLE static bool copyToClipboard(const QString &text);
 	Q_INVOKABLE static QString createVCardFile(const QString &username, const QString &vcardAsString);
+	// Bulk contact import: parses every vCard in the given file and adds each
+	// as a Friend to the app's contact list. Runs on the linphone thread;
+	// the returned VariantObject's `value` becomes the imported count once
+	// ready (0 or -1 on failure/bad path).
+	Q_INVOKABLE static VariantObject *importVCardFile(const QUrl &fileUrl);
 	Q_INVOKABLE static void shareByEmail(const QString &subject,
 	                                     const QString &body = QString(),
 	                                     const QString &attachment = QString(),

--- a/Linphone/tool/Utils.hpp
+++ b/Linphone/tool/Utils.hpp
@@ -105,11 +105,10 @@ public:
 	Q_INVOKABLE static int getRandomIndex(int size);
 	Q_INVOKABLE static bool copyToClipboard(const QString &text);
 	Q_INVOKABLE static QString createVCardFile(const QString &username, const QString &vcardAsString);
-	// Bulk contact import: parses every vCard in the given file and adds each
-	// as a Friend to the app's contact list. Runs on the linphone thread;
-	// the returned VariantObject's `value` becomes the imported count once
-	// ready (0 or -1 on failure/bad path).
+	// Result's `value` becomes the imported count (0 or -1 on failure/bad path).
 	Q_INVOKABLE static VariantObject *importVCardFile(const QUrl &fileUrl);
+	// Fire-and-forget from QML; result is reported via a popup once the async import completes.
+	Q_INVOKABLE static void importExtensionsFromPbx();
 	Q_INVOKABLE static void shareByEmail(const QString &subject,
 	                                     const QString &body = QString(),
 	                                     const QString &attachment = QString(),

--- a/Linphone/view/CMakeLists.txt
+++ b/Linphone/view/CMakeLists.txt
@@ -163,6 +163,7 @@ list(APPEND _LINPHONEAPP_QML_FILES
 	view/Page/Layout/Settings/SecuritySettingsLayout.qml
 	view/Page/Layout/Settings/NetworkSettingsLayout.qml
 	view/Page/Layout/Settings/AdvancedSettingsLayout.qml
+	view/Page/Layout/Settings/PbxSettingsLayout.qml
 	view/Page/Layout/Chat/MessageImdnStatusInfos.qml
 	view/Page/Layout/Chat/MessageInfosLayout.qml
 	view/Page/Layout/Chat/MessageReactionsInfos.qml

--- a/Linphone/view/Control/Display/Contact/ContactListItem.qml
+++ b/Linphone/view/Control/Display/Contact/ContactListItem.qml
@@ -73,12 +73,27 @@ FocusScope {
             anchors.bottom: parent.bottom
             spacing: Utils.getSizeWithScreenRatio(16)
             z: contactArea.z + 1
-            Avatar {
+            Item {
                 Layout.preferredWidth: Utils.getSizeWithScreenRatio(45)
                 Layout.preferredHeight: Utils.getSizeWithScreenRatio(45)
                 Layout.leftMargin: Utils.getSizeWithScreenRatio(5)
-                contact: searchResultItem
-                shadowEnabled: false
+                Avatar {
+                    anchors.fill: parent
+                    contact: searchResultItem
+                    shadowEnabled: false
+                }
+                // BLF (Busy Lamp Field) indicator: idle/ringing/busy, driven by dialog-info NOTIFYs.
+                Rectangle {
+                    visible: searchResultItem.core.dialogMonitoringEnabled
+                    width: Utils.getSizeWithScreenRatio(13)
+                    height: width
+                    radius: width / 2
+                    color: searchResultItem.core.dialogStateColor
+                    border.color: DefaultStyle.main2_0
+                    border.width: Utils.getSizeWithScreenRatio(2)
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                }
             }
             ColumnLayout {
                 spacing: 0
@@ -222,6 +237,20 @@ FocusScope {
                             onClicked: {
                                 searchResultItem.core.lSetStarred(
                                             !searchResultItem.core.starred)
+                                friendPopup.close()
+                            }
+                            style: ButtonStyle.noBackground
+                        }
+                        IconLabelButton {
+                            Layout.fillWidth: true
+                            visible: searchResultItem && searchResultItem.core.looksLikeSipExtension
+                            text: searchResultItem.core.dialogMonitoringEnabled ? qsTr("Arrêter le suivi BLF")
+                                                                                : qsTr("Suivre l'état (BLF)")
+                            icon.source: AppIcons.phone
+                            spacing: Utils.getSizeWithScreenRatio(10)
+                            textColor: DefaultStyle.main2_500_main
+                            onClicked: {
+                                searchResultItem.core.toggleDialogMonitoring()
                                 friendPopup.close()
                             }
                             style: ButtonStyle.noBackground

--- a/Linphone/view/Page/Form/Settings/SettingsPage.qml
+++ b/Linphone/view/Page/Form/Settings/SettingsPage.qml
@@ -28,7 +28,9 @@ AbstractSettingsMenu {
         //: "Réseau"
         {title: qsTr("settings_network_title"), layout: "NetworkSettingsLayout"},
         //: "Paramètres avancés"
-        {title: qsTr("settings_advanced_title"), layout: "AdvancedSettingsLayout"}
+        {title: qsTr("settings_advanced_title"), layout: "AdvancedSettingsLayout"},
+        //: "Intégration PBX"
+        {title: qsTr("settings_pbx_title"), layout: "PbxSettingsLayout"}
 	]
 
 	onGoBackRequested: mainItem.goBack()

--- a/Linphone/view/Page/Layout/Settings/PbxSettingsLayout.qml
+++ b/Linphone/view/Page/Layout/Settings/PbxSettingsLayout.qml
@@ -1,0 +1,60 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls.Basic as Control
+import Linphone
+import SettingsCpp 1.0
+import UtilsCpp
+import "qrc:/qt/qml/Linphone/view/Control/Tool/Helper/utils.js" as Utils
+
+AbstractSettingsLayout {
+	id: mainItem
+	width: parent?.width
+
+	contentModel: [
+		{
+			title: "",
+			subTitle: "",
+			contentComponent: parametersComponent
+		}
+	]
+
+	onSave: SettingsCpp.save()
+	onUndo: SettingsCpp.undo()
+
+	Component {
+		id: parametersComponent
+		ColumnLayout {
+			spacing: Utils.getSizeWithScreenRatio(20)
+			Text {
+				Layout.fillWidth: true
+				wrapMode: Text.WordWrap
+				//: "Utilisé pour le statut BLF en ligne/hors ligne et l'import des interlocuteurs"
+				text: qsTr("settings_pbx_description")
+				font {
+					pixelSize: Typography.p2l.pixelSize
+					weight: Typography.p2l.weight
+				}
+			}
+			DecoratedTextField {
+				id: pbxApiBaseUrlField
+				Layout.fillWidth: true
+				propertyName: "pbxApiBaseUrl"
+				propertyOwner: SettingsCpp
+				//: "URL du PBX"
+				title: qsTr("settings_pbx_base_url_title")
+				placeHolder: "https://pbx.example.com"
+				useTitleAsPlaceHolder: false
+			}
+			DecoratedTextField {
+				id: pbxApiKeyField
+				Layout.fillWidth: true
+				propertyName: "pbxApiKey"
+				propertyOwner: SettingsCpp
+				//: "Clé API"
+				title: qsTr("settings_pbx_api_key_title")
+				useTitleAsPlaceHolder: true
+				hidden: true
+			}
+		}
+	}
+}

--- a/Linphone/view/Page/Layout/Settings/PbxSettingsLayout.qml
+++ b/Linphone/view/Page/Layout/Settings/PbxSettingsLayout.qml
@@ -40,6 +40,7 @@ AbstractSettingsLayout {
 				Layout.fillWidth: true
 				propertyName: "pbxApiBaseUrl"
 				propertyOwner: SettingsCpp
+				toValidate: true
 				//: "URL du PBX"
 				title: qsTr("settings_pbx_base_url_title")
 				placeHolder: "https://pbx.example.com"
@@ -50,6 +51,7 @@ AbstractSettingsLayout {
 				Layout.fillWidth: true
 				propertyName: "pbxApiKey"
 				propertyOwner: SettingsCpp
+				toValidate: true
 				//: "Clé API"
 				title: qsTr("settings_pbx_api_key_title")
 				useTitleAsPlaceHolder: true

--- a/Linphone/view/Page/Main/Contact/ContactPage.qml
+++ b/Linphone/view/Page/Main/Contact/ContactPage.qml
@@ -268,6 +268,20 @@ AbstractMainPage {
                 Accessible.name: qsTr("import_contacts_accessible_name")
             }
             Button {
+                id: importFromPbxButton
+                visible: !rightPanelStackView.currentItem
+                         || rightPanelStackView.currentItem.objectName !== "contactEdition"
+                style: ButtonStyle.noBackground
+                icon.source: AppIcons.download
+                Layout.preferredWidth: Utils.getSizeWithScreenRatio(28)
+                Layout.preferredHeight: Utils.getSizeWithScreenRatio(28)
+                icon.width: Utils.getSizeWithScreenRatio(28)
+                icon.height: Utils.getSizeWithScreenRatio(28)
+                onClicked: UtilsCpp.importExtensionsFromPbx()
+                //: Import contacts from the PBX extension list
+                Accessible.name: qsTr("import_contacts_from_pbx_accessible_name")
+            }
+            Button {
                 id: createContactButton
                 visible: !rightPanelStackView.currentItem
                          || rightPanelStackView.currentItem.objectName !== "contactEdition"

--- a/Linphone/view/Page/Main/Contact/ContactPage.qml
+++ b/Linphone/view/Page/Main/Contact/ContactPage.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Dialogs
 import QtQuick.Effects
 import QtQuick.Layouts
 import QtQuick.Controls.Basic as Control
@@ -253,6 +254,20 @@ AbstractMainPage {
                 font.weight: Typography.h2.weight
             }
             Button {
+                id: importContactsButton
+                visible: !rightPanelStackView.currentItem
+                         || rightPanelStackView.currentItem.objectName !== "contactEdition"
+                style: ButtonStyle.noBackground
+                icon.source: AppIcons.filePlus
+                Layout.preferredWidth: Utils.getSizeWithScreenRatio(28)
+                Layout.preferredHeight: Utils.getSizeWithScreenRatio(28)
+                icon.width: Utils.getSizeWithScreenRatio(28)
+                icon.height: Utils.getSizeWithScreenRatio(28)
+                onClicked: importVCardDialog.open()
+                //: Import contacts from a vCard file
+                Accessible.name: qsTr("import_contacts_accessible_name")
+            }
+            Button {
                 id: createContactButton
                 visible: !rightPanelStackView.currentItem
                          || rightPanelStackView.currentItem.objectName !== "contactEdition"
@@ -269,6 +284,33 @@ AbstractMainPage {
                 KeyNavigation.down: searchBar
                 //: Create new contact
                 Accessible.name: qsTr("create_contact_accessible_name")
+            }
+        }
+
+        FileDialog {
+            id: importVCardDialog
+            nameFilters: ["vCard files (*.vcf)"]
+            onAccepted: {
+                var request = UtilsCpp.importVCardFile(selectedFile)
+                if (request) importVCardResult.target = request
+            }
+        }
+        Connections {
+            id: importVCardResult
+            function onValueChanged() {
+                var count = target.value
+                if (count > 0) {
+                    //: "Contacts importés"
+                    UtilsCpp.showInformationPopup(qsTr("information_popup_success_title"),
+                                                  qsTr("information_popup_vcard_import_success_message").arg(count),
+                                                  true)
+                } else {
+                    //: "Aucun contact n'a pu être importé depuis ce fichier."
+                    UtilsCpp.showInformationPopup(qsTr("information_popup_error_title"),
+                                                  qsTr("information_popup_vcard_import_error_message"),
+                                                  false)
+                }
+                target = null
             }
         }
 


### PR DESCRIPTION
## Summary

This builds on #1009 (BLF dialog-info monitoring) to solve the gap discussed in #1006: dialog-info alone can't distinguish a genuinely idle-but-registered extension from an unregistered one, since both produce an empty dialog-info body.

- Adds an **optional** overlay that polls MikoPBX's own REST API (`/pbxcore/api/v3/sip/{ext}:getStatus`) for real device-registration state, and forces the BLF badge to "unregistered" whenever the extension has zero registered devices — regardless of dialog-info's last reported state. No-ops entirely when the new PBX settings are left unconfigured, so behavior for everyone else is unchanged.
- Adds bulk contact import from MikoPBX's extension list (`/pbxcore/api/v3/extensions`), and a "PBX integration" Settings page to configure the base URL/API key used by both features.

**This is intentionally vendor-specific**, not a generic PBX abstraction. I looked into generalizing it (see the discussion on #1006): MikoPBX appears to be the exception rather than the rule here — its REST API is the only one I found among Asterisk-based PBX distros that exposes real device/registration status at all. I checked FreePBX's official GraphQL API (`FreePBX/core`) in detail and it only exposes configuration + manually-declared presence (away/DND), not live registration state, so there's currently no shared shape to build a generic abstraction against.

Opening this as a separate PR from #1009 specifically so it's easy to reject/merge independently — happy to hear whether a vendor-specific integration like this has a place in this repo at all, or whether it'd be better as a documented pattern/example for others running MikoPBX to fork from.

## Test plan

- [x] Built on Windows (MSVC/Qt6/Ninja) against current `master`, 554/554 targets, no errors
- [x] Verified `linphone.exe` launches and stays running (no crash)
- [x] Manually verified against a live MikoPBX instance: extension bulk-import populates real contacts, PBX settings page persists/loads URL+key correctly, presence overlay correctly grays out an extension when its SIP client deregisters
