### PR TITLE
Fix dialpad ignoring non-numpad keyboard digits and missing # handling

### DIFF
--- a/Linphone/view/Control/Input/NumericPad.qml
+++ b/Linphone/view/Control/Input/NumericPad.qml
@@ -86,6 +86,10 @@ FocusScope {
 			keypadKeyPressedAtIndex(9)
 			event.accepted = true
 		}
+		if (event.key === Qt.Key_NumberSign) {
+			keypadKeyPressedAtIndex(11)
+			event.accepted = true
+		}
 		if (event.key === Qt.Key_Plus) {
 			mainItem.buttonPressed("+")
 			event.accepted = true
@@ -98,9 +102,7 @@ FocusScope {
 
 	Keys.onPressed: (event) => {
 		event.accepted = false
-		if (event.modifiers & Qt.KeypadModifier || event.key === Qt.Key_Return) {
-			handleKeyPadEvent(event)
-		}
+		handleKeyPadEvent(event)
 		if (event.key === Qt.Key_Backspace) {
 			mainItem.wipe()
 			event.accepted = true

--- a/Linphone/view/Page/Window/Call/CallsWindow.qml
+++ b/Linphone/view/Page/Window/Call/CallsWindow.qml
@@ -962,59 +962,61 @@ AbstractWindow {
                                 Connections {
                                     target: mainWindow
                                     function onKeyPressedOnDialer(event) {
-                                        if (event.modifiers & Qt.KeypadModifier) {
-                                            if (event.key === Qt.Key_0) {
-                                                numPad.keypadKeyPressedAtIndex(10)
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_1) {
-                                                numPad.keypadKeyPressedAtIndex(0)
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_2) {
-                                                numPad.keypadKeyPressedAtIndex(1)
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_3) {
-                                                numPad.keypadKeyPressedAtIndex(2)
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_4) {
-                                                numPad.keypadKeyPressedAtIndex(3)
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_5) {
-                                                numPad.keypadKeyPressedAtIndex(4)
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_6) {
-                                                numPad.keypadKeyPressedAtIndex(5)
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_7) {
-                                                numPad.keypadKeyPressedAtIndex(6)
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_8) {
-                                                numPad.keypadKeyPressedAtIndex(7)
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_9) {
-                                                numPad.keypadKeyPressedAtIndex(8)
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_Asterisk) {
-                                                numPad.keypadKeyPressedAtIndex(9)
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_Plus) {
-                                                numPad.buttonPressed("+")
-                                                event.accepted = true
-                                            }
-                                            if (event.key === Qt.Key_Enter) {
-                                                numPad.launchCall()
-                                                event.accepted = true
-                                            }
+                                        if (event.key === Qt.Key_0) {
+                                            numPad.keypadKeyPressedAtIndex(10)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_1) {
+                                            numPad.keypadKeyPressedAtIndex(0)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_2) {
+                                            numPad.keypadKeyPressedAtIndex(1)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_3) {
+                                            numPad.keypadKeyPressedAtIndex(2)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_4) {
+                                            numPad.keypadKeyPressedAtIndex(3)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_5) {
+                                            numPad.keypadKeyPressedAtIndex(4)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_6) {
+                                            numPad.keypadKeyPressedAtIndex(5)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_7) {
+                                            numPad.keypadKeyPressedAtIndex(6)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_8) {
+                                            numPad.keypadKeyPressedAtIndex(7)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_9) {
+                                            numPad.keypadKeyPressedAtIndex(8)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_Asterisk) {
+                                            numPad.keypadKeyPressedAtIndex(9)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_NumberSign) {
+                                            numPad.keypadKeyPressedAtIndex(11)
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_Plus) {
+                                            numPad.buttonPressed("+")
+                                            event.accepted = true
+                                        }
+                                        if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return) {
+                                            numPad.launchCall()
+                                            event.accepted = true
                                         }
                                         if (event.key === Qt.Key_Backspace) {
                                             numPad.wipe()


### PR DESCRIPTION
## Summary

While investigating a report of the in-call dialpad "losing" digits typed on the keyboard, I found the keyboard-forwarding logic (duplicated in `Linphone/view/Control/Input/NumericPad.qml`'s `Keys.onPressed` and in `Linphone/view/Page/Window/Call/CallsWindow.qml`'s dialer-popup `onKeyPressedOnDialer` handler) gates *all* digit/`*`/`+`/Enter handling behind `event.modifiers & Qt.KeypadModifier`. On a keyboard without a physical numpad — most laptops — typing digits during a call produces no DTMF at all, since the top-row number keys never carry `Qt.KeypadModifier`.

Git blame points to 389fae13d ("Activate numeric pad buttons with numpad keyboard in calls window #LINQT-2310") as the origin of the restriction, presumably to avoid stealing keystrokes from the in-call `SearchBar`. That `SearchBar` is now instantiated with `enabled: false` in the dialer popup, so the conflict it guarded against no longer exists.

- Removes the `Qt.KeypadModifier` gate in both copies so digits typed from the main keyboard row work the same as the physical numpad.
- Adds handling for `Qt.Key_NumberSign` (`#`), which had no handler at all in either copy.
- (`CallsWindow.qml` only) also accepts `Key_Return` in addition to `Key_Enter` for launching a call from the dialer popup, matching `NumericPad.qml`'s own handler, for consistency between the two copies.

This is likely a distinct root cause from #974 (digit reordering when typing fast via the physical numpad) rather than a duplicate — that one is about ordering under load, this one is a hard "nothing happens" for any user without a numpad. Filing separately so they can be triaged/merged independently; happy to fold into #974's thread instead if maintainers prefer.

## Test plan

- [x] Built on Windows (MSVC/Qt6/Ninja) against current `master`, 552/552 targets, no errors (QML AOT compilation via qmlcachegen also exercises these exact files at build time)
- [x] Verified `linphone.exe` launches and stays running (no crash)
- [ ] Manual verification of DTMF during a live call from a non-numpad keyboard — happy to do this against my own PBX if useful, or defer to maintainer testing
