### PR TITLE
Fix belr grammar loading depending on the process working directory

### DIFF
--- a/Linphone/model/core/CoreModel.cpp
+++ b/Linphone/model/core/CoreModel.cpp
@@ -28,6 +28,8 @@
 #include <QSysInfo>
 #include <QTimer>
 
+#include <belr/grammarbuilder.h>
+
 #include "core/App.hpp"
 #include "core/notifier/Notifier.hpp"
 #include "core/path/Paths.hpp"
@@ -168,6 +170,9 @@ void CoreModel::refreshOidcRemainingTime() {
 	} while (0);
 
 void CoreModel::setPathBeforeCreation() {
+	// GrammarLoader's fallback path is relative to the CWD, not the executable; pin it explicitly.
+	belr::GrammarLoader::get().addPath((QCoreApplication::applicationDirPath() + "/share/belr/grammars").toStdString());
+
 	std::shared_ptr<linphone::Factory> factory = linphone::Factory::get();
 	SET_FACTORY_PATH(Msplugins, Paths::getPackageMsPluginsDirPath());
 	SET_FACTORY_PATH(TopResources, Paths::getPackageTopDirPath());


### PR DESCRIPTION
## Summary

Found while debugging a distinct crash report: `linphone.exe` fails with `STATUS_STACK_BUFFER_OVERRUN` inside `ucrtbase.dll` (`abort()`, called from `bctoolbox!bctbx_logv` via `belcard::BelCardParser`'s `bctbx_fatal("Unable to load VCARD grammar.")`) on any machine other than the one it was built on — reproduced deterministically in a clean Windows Sandbox VM, confirmed against unmodified `master`.

Root cause: `belr::GrammarLoader` looks for its grammar files first at an absolute path baked in at SDK build time (`CMAKE_INSTALL_PREFIX`-derived — only valid on the build machine), then falls back to a path relative to the process's **current working directory**, not the executable's location. That fallback only happens to work when the app is launched in a way that sets CWD to its own directory (e.g. some double-click scenarios) and fails silently (hard `abort()`) otherwise — a shortcut with a different "Start in" folder, a taskbar pin, a CLI launch from elsewhere, or simply distributing the built binaries without replicating the exact build-machine directory layout.

Fix: explicitly register the app's own `share/belr/grammars` directory with `belr::GrammarLoader::addPath()` before core creation, so grammar lookup no longer depends on the working directory at all.

## Test plan

- [x] Built on Windows (MSVC/Qt6/Ninja) against current `master`, 225/225 targets, no errors
- [x] Reproduced the crash in a clean Windows Sandbox VM (no dev tools, different `ucrtbase.dll` build than the dev machine) against unmodified `master`
- [x] Confirmed the fix resolves it in the same clean VM, including when launched with a working directory different from the executable's own folder (the actual scenario this fixes, not just the common double-click case)
