### PR TITLE
Complete the Italian (it.ts) translation

### DIFF
--- a/Linphone/data/languages/it.ts
+++ b/Linphone/data/languages/it.ts
@@ -4,19 +4,19 @@
 <context>
     <name>AbstractSettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AbstractSettingsLayout.qml" line="67"/>
+        <location filename="../../view/Page/Layout/Settings/AbstractSettingsLayout.qml" line="67" />
         <source>return_accessible_name</source>
         <extracomment>Return</extracomment>
         <translation>indietro</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AbstractSettingsLayout.qml" line="86"/>
+        <location filename="../../view/Page/Layout/Settings/AbstractSettingsLayout.qml" line="86" />
         <source>save</source>
-        <extracomment>&quot;Enregistrer&quot;</extracomment>
+        <extracomment>"Enregistrer"</extracomment>
         <translation>Salvare</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AbstractSettingsLayout.qml" line="90"/>
+        <location filename="../../view/Page/Layout/Settings/AbstractSettingsLayout.qml" line="90" />
         <source>save_settings_accessible_name</source>
         <extracomment>Save %1 settings</extracomment>
         <translation>Salva le impostazioni</translation>
@@ -25,13 +25,13 @@
 <context>
     <name>AbstractSettingsMenu</name>
     <message>
-        <location filename="../../view/Page/Form/Settings/AbstractSettingsMenu.qml" line="52"/>
+        <location filename="../../view/Page/Form/Settings/AbstractSettingsMenu.qml" line="52" />
         <source>back_previous_menu_accessible_name</source>
         <extracomment>Back to previous menu</extracomment>
         <translation>Torna al menù precedete</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/AbstractSettingsMenu.qml" line="76"/>
+        <location filename="../../view/Page/Form/Settings/AbstractSettingsMenu.qml" line="76" />
         <source>settings_page_selection_accessible_name</source>
         <extracomment>Settings page selection</extracomment>
         <translation>Schermata Impostazioni</translation>
@@ -40,13 +40,13 @@
 <context>
     <name>AbstractWindow</name>
     <message>
-        <location filename="../../view/Page/Window/AbstractWindow.qml" line="82"/>
+        <location filename="../../view/Page/Window/AbstractWindow.qml" line="82" />
         <source>contact_dialog_pick_phone_number_or_sip_address_title</source>
-        <extracomment>&quot;Choisissez un numéro ou adresse SIP&quot;</extracomment>
-        <translation>Scegli il numero o l&apos;indirizzo SIP</translation>
+        <extracomment>"Choisissez un numéro ou adresse SIP"</extracomment>
+        <translation>Scegli il numero o l'indirizzo SIP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/AbstractWindow.qml" line="329"/>
+        <location filename="../../view/Page/Window/AbstractWindow.qml" line="329" />
         <source>fps_counter</source>
         <translation>%1 FPS (fotogrammi al secondo)</translation>
     </message>
@@ -54,63 +54,63 @@
 <context>
     <name>AccountCore</name>
     <message>
-        <location filename="../../core/account/AccountCore.cpp" line="464"/>
+        <location filename="../../core/account/AccountCore.cpp" line="464" />
         <source>drawer_menu_account_connection_status_connected</source>
-        <extracomment>&quot;Connecté&quot;</extracomment>
+        <extracomment>"Connecté"</extracomment>
         <translation>Collegato</translation>
     </message>
     <message>
-        <location filename="../../core/account/AccountCore.cpp" line="467"/>
+        <location filename="../../core/account/AccountCore.cpp" line="467" />
         <source>drawer_menu_account_connection_status_refreshing</source>
         <translation>Ricaricamento…</translation>
     </message>
     <message>
-        <location filename="../../core/account/AccountCore.cpp" line="470"/>
+        <location filename="../../core/account/AccountCore.cpp" line="470" />
         <source>drawer_menu_account_connection_status_progress</source>
         <translation>Connessione…</translation>
     </message>
     <message>
-        <location filename="../../core/account/AccountCore.cpp" line="473"/>
+        <location filename="../../core/account/AccountCore.cpp" line="473" />
         <source>drawer_menu_account_connection_status_failed</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../core/account/AccountCore.cpp" line="477"/>
+        <location filename="../../core/account/AccountCore.cpp" line="477" />
         <source>drawer_menu_account_connection_status_cleared</source>
         <translation>Disattivato</translation>
     </message>
     <message>
-        <location filename="../../core/account/AccountCore.cpp" line="511"/>
+        <location filename="../../core/account/AccountCore.cpp" line="511" />
         <source>manage_account_status_connected_summary</source>
-        <extracomment>&quot;Vous êtes en ligne et joignable.&quot;</extracomment>
+        <extracomment>"Vous êtes en ligne et joignable."</extracomment>
         <translation>Sei connesso e raggiungibile.</translation>
     </message>
     <message>
-        <location filename="../../core/account/AccountCore.cpp" line="514"/>
+        <location filename="../../core/account/AccountCore.cpp" line="514" />
         <source>manage_account_status_failed_summary</source>
-        <extracomment>&quot;Erreur de connexion, vérifiez vos paramètres.&quot;</extracomment>
+        <extracomment>"Erreur de connexion, vérifiez vos paramètres."</extracomment>
         <translation>Errore di connessione, controlla le impostazioni.</translation>
     </message>
     <message>
-        <location filename="../../core/account/AccountCore.cpp" line="518"/>
+        <location filename="../../core/account/AccountCore.cpp" line="518" />
         <source>manage_account_status_cleared_summary</source>
-        <extracomment>&quot;Compte désactivé, vous ne recevrez ni appel ni message.&quot;</extracomment>
+        <extracomment>"Compte désactivé, vous ne recevrez ni appel ni message."</extracomment>
         <translation>Account disabilitato. Non riceverai chiamate o messaggi.</translation>
     </message>
 </context>
 <context>
     <name>AccountDeviceList</name>
     <message>
-        <location filename="../../core/account/AccountDeviceList.cpp" line="156"/>
+        <location filename="../../core/account/AccountDeviceList.cpp" line="156" />
         <source>manage_account_no_device_found_error_message</source>
-        <extracomment>&quot;Erreur lors de la récupération des appareils&quot;</extracomment>
+        <extracomment>"Erreur lors de la récupération des appareils"</extracomment>
         <translation>Errore nel recupero dei dispositivi: %1</translation>
     </message>
 </context>
 <context>
     <name>AccountListView</name>
     <message>
-        <location filename="../../view/Page/Main/Account/AccountListView.qml" line="87"/>
+        <location filename="../../view/Page/Main/Account/AccountListView.qml" line="87" />
         <source>add_an_account</source>
         <extracomment>Add an account</extracomment>
         <translation>Aggiungi un account</translation>
@@ -119,280 +119,280 @@
 <context>
     <name>AccountManager</name>
     <message>
-        <location filename="../../model/account/AccountManager.cpp" line="94"/>
+        <location filename="../../model/account/AccountManager.cpp" line="94" />
         <source>assistant_account_login_already_connected_error</source>
-        <extracomment>&quot;The account is already connected&quot;</extracomment>
-        <translation>L&apos;account risulta già connesso.</translation>
+        <extracomment>"The account is already connected"</extracomment>
+        <translation>L'account risulta già connesso.</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountManager.cpp" line="144"/>
+        <location filename="../../model/account/AccountManager.cpp" line="144" />
         <source>assistant_account_login_outbound_proxy_uri_error</source>
         <extracomment>Outbound proxy uri is invalid. Please make sure it matches the following format : sip:host&gt;:&lt;port&gt;;transport=&lt;transport&gt; (:&lt;port&gt; is optional)</extracomment>
-        <translation>L&apos;URI del proxy in uscita non è valido. Assicurati che rispetti il seguente formato : sip:host&gt;:&lt;port&gt;;transport=&lt;transport&gt; (:&lt;port&gt; e opzionale)</translation>
+        <translation>L'URI del proxy in uscita non è valido. Assicurati che rispetti il seguente formato : sip:host&gt;:&lt;port&gt;;transport=&lt;transport&gt; (:&lt;port&gt; e opzionale)</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountManager.cpp" line="109"/>
+        <location filename="../../model/account/AccountManager.cpp" line="109" />
         <source>assistant_account_login_proxy_address_error</source>
-        <extracomment>&quot;Unable to create proxy address. Please check the domain name.&quot;</extracomment>
-        <translation>Impossibile creare l&apos;indirizzo del proxy. Assicurati che il nome di dominio sia corretto.</translation>
+        <extracomment>"Unable to create proxy address. Please check the domain name."</extracomment>
+        <translation>Impossibile creare l'indirizzo del proxy. Assicurati che il nome di dominio sia corretto.</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountManager.cpp" line="122"/>
+        <location filename="../../model/account/AccountManager.cpp" line="122" />
         <source>assistant_account_login_address_configuration_error</source>
-        <extracomment>&quot;Unable to configure address: `%1`.&quot;</extracomment>
-        <translation>Non è stato possibile configurare l&apos;indirizzo: `%1`.</translation>
+        <extracomment>"Unable to configure address: `%1`."</extracomment>
+        <translation>Non è stato possibile configurare l'indirizzo: `%1`.</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountManager.cpp" line="133"/>
+        <location filename="../../model/account/AccountManager.cpp" line="133" />
         <source>assistant_account_login_registrar_uri_error</source>
         <extracomment>Registrar uri is invalid. Please make sure it matches the following format : sip:host&gt;:&lt;port&gt;;transport=&lt;transport&gt; (:&lt;port&gt; is optional)</extracomment>
-        <translation>L&apos;URI del registrar non è valido. Assicurati che rispetti il seguente formato: sip:&lt;host&gt;:&lt;port&gt;;transport=&lt;transport&gt; (:&lt;port&gt; è opzionale).</translation>
+        <translation>L'URI del registrar non è valido. Assicurati che rispetti il seguente formato: sip:&lt;host&gt;:&lt;port&gt;;transport=&lt;transport&gt; (:&lt;port&gt; è opzionale).</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountManager.cpp" line="151"/>
+        <location filename="../../model/account/AccountManager.cpp" line="151" />
         <source>assistant_account_login_params_configuration_error</source>
-        <extracomment>&quot;Unable to configure account settings.&quot;</extracomment>
-        <translation>Impossibile configurare le impostazioni dell&apos;account.</translation>
+        <extracomment>"Unable to configure account settings."</extracomment>
+        <translation>Impossibile configurare le impostazioni dell'account.</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountManager.cpp" line="175"/>
+        <location filename="../../model/account/AccountManager.cpp" line="175" />
         <source>assistant_account_login_forbidden_error</source>
-        <extracomment>&quot;Username and password do not match&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Username and password do not match"</extracomment>
+        <translation>Nome utente e password non corrispondono</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountManager.cpp" line="177"/>
+        <location filename="../../model/account/AccountManager.cpp" line="177" />
         <source>assistant_account_login_error</source>
-        <extracomment>&quot;Error during connection, please verify your parameters&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Error during connection, please verify your parameters"</extracomment>
+        <translation>Errore durante la connessione</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountManager.cpp" line="192"/>
+        <location filename="../../model/account/AccountManager.cpp" line="192" />
         <source>assistant_account_add_error</source>
-        <extracomment>&quot;Unable to add account.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Unable to add account."</extracomment>
+        <translation>Impossibile aggiungere l'account.</translation>
     </message>
 </context>
 <context>
     <name>AccountModel</name>
     <message>
-        <location filename="../../model/account/AccountModel.cpp" line="253"/>
+        <location filename="../../model/account/AccountModel.cpp" line="253" />
         <source>set_mwi_server_address_failed_error_message</source>
-        <extracomment>&quot;Unable to set voicemail server address, failed creating address from %1&quot; : %1 is address</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Unable to set voicemail server address, failed creating address from %1" : %1 is address</extracomment>
+        <translation>Impossibile impostare l'indirizzo del server di segreteria, creazione dell'indirizzo da %1 non riuscita</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountModel.cpp" line="292"/>
+        <location filename="../../model/account/AccountModel.cpp" line="292" />
         <source>set_server_address_failed_error_message</source>
-        <extracomment>&quot;Unable to set server address, failed creating address from %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Unable to set server address, failed creating address from %1"</extracomment>
+        <translation>Impossibile impostare l'indirizzo del server, creazione dell'indirizzo da %1 non riuscita</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountModel.cpp" line="310"/>
+        <location filename="../../model/account/AccountModel.cpp" line="310" />
         <source>set_outbound_proxy_uri_failed_error_message</source>
         <extracomment>Unable to set outbound proxy uri from address %1. Please make sure it matches the following format : sip:host&gt;:&lt;port&gt;;transport=&lt;transport&gt; (:&lt;port&gt; is optional)</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile impostare l'URI del proxy in uscita dall'indirizzo %1. Assicurati che rispetti il seguente formato: sip:host&amp;gt;:&amp;lt;porta&amp;gt;;transport=&amp;lt;trasporto&amp;gt; (:&amp;lt;porta&amp;gt; è opzionale)</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountModel.cpp" line="419"/>
+        <location filename="../../model/account/AccountModel.cpp" line="419" />
         <source>set_conference_factory_address_failed_error_message</source>
-        <extracomment>&quot;Unable to set the conversation server address, failed creating address from %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Unable to set the conversation server address, failed creating address from %1"</extracomment>
+        <translation>Impossibile impostare l'indirizzo del server di conversazione, creazione dell'indirizzo da %1 non riuscita</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountModel.cpp" line="441"/>
+        <location filename="../../model/account/AccountModel.cpp" line="441" />
         <source>set_audio_conference_factory_address_failed_error_message</source>
-        <extracomment>&quot;Unable to set the meeting server address, failed creating address from %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Unable to set the meeting server address, failed creating address from %1"</extracomment>
+        <translation>Impossibile impostare l'indirizzo del server di riunione, creazione dell'indirizzo da %1 non riuscita</translation>
     </message>
     <message>
-        <location filename="../../model/account/AccountModel.cpp" line="488"/>
+        <location filename="../../model/account/AccountModel.cpp" line="488" />
         <source>set_voicemail_address_failed_error_message</source>
         <extracomment>Unable to set voicemail address, failed creating address from %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile impostare l'indirizzo della segreteria, creazione dell'indirizzo da %1 non riuscita</translation>
     </message>
 </context>
 <context>
     <name>AccountSettingsGeneralLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="20"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="20" />
         <source>manage_account_details_title</source>
-        <extracomment>&quot;Détails&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Détails"</extracomment>
+        <translation>Dettagli</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="22"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="22" />
         <source>manage_account_details_subtitle</source>
         <extracomment>Éditer les informations de votre compte.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Modifica le informazioni del tuo account.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="28"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="28" />
         <source>manage_account_devices_title</source>
-        <extracomment>&quot;Vos appareils&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vos appareils"</extracomment>
+        <translation>I tuoi dispositivi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="30"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="30" />
         <source>manage_account_devices_subtitle</source>
-        <extracomment>&quot;La liste des appareils connectés à votre compte. Vous pouvez retirer les appareils que vous n’utilisez plus.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"La liste des appareils connectés à votre compte. Vous pouvez retirer les appareils que vous n’utilisez plus."</extracomment>
+        <translation>L'elenco dei dispositivi collegati al tuo account. Puoi rimuovere i dispositivi che non usi più.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="60"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="60" />
         <source>manage_account_add_picture</source>
-        <extracomment>&quot;Ajouter une image&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter une image"</extracomment>
+        <translation>Aggiungi un'immagine</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="75"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="75" />
         <source>manage_account_edit_picture</source>
-        <extracomment>&quot;Modifier l&apos;image&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Modifier l'image"</extracomment>
+        <translation>Modifica immagine</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="85"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="85" />
         <source>manage_account_remove_picture</source>
-        <extracomment>&quot;Supprimer l&apos;image&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer l'image"</extracomment>
+        <translation>Elimina immagine</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="107"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="107" />
         <source>sip_address</source>
         <extracomment>SIP address</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Indirizzo SIP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="127"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="127" />
         <source>copied</source>
         <extracomment>Copied</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Copiato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="129"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="129" />
         <source>account_settings_sip_address_copied_message</source>
         <extracomment>Your SIP address has been copied in the clipboard</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Il tuo indirizzo SIP è stato copiato negli appunti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="133"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="133" />
         <source>account_settings_sip_address_copied_error_message</source>
         <extracomment>Error copying your SIP address</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Errore durante la copia dell'indirizzo SIP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="143"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="143" />
         <source>sip_address_display_name</source>
-        <extracomment>&quot;Nom d&apos;affichage</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nom d'affichage</extracomment>
+        <translation>Nome visualizzato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="149"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="149" />
         <source>sip_address_display_name_explaination</source>
-        <extracomment>&quot;Le nom qui sera affiché à vos correspondants lors de vos échanges.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le nom qui sera affiché à vos correspondants lors de vos échanges."</extracomment>
+        <translation>Il nome mostrato ai tuoi contatti durante le conversazioni.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="167"/>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="179"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="167" />
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="179" />
         <source>manage_account_international_prefix</source>
         <extracomment>Indicatif international*</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Prefisso internazionale*</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="194"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="194" />
         <source>manage_account_delete</source>
-        <extracomment>&quot;Déconnecter mon compte&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Déconnecter mon compte"</extracomment>
+        <translation>Disconnetti il mio account</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="202"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="202" />
         <source>manage_account_delete_message</source>
-        <translation type="unfinished"></translation>
+        <translation>Il tuo account verrà rimosso da questo client Linphone, ma resterai connesso sugli altri tuoi client</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="221"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="221" />
         <source>manage_account_dialog_remove_account_title</source>
-        <extracomment>&quot;Se déconnecter du compte ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Se déconnecter du compte ?"</extracomment>
+        <translation>Disconnettersi dall'account?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="223"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="223" />
         <source>manage_account_dialog_remove_account_message</source>
         <extracomment>Si vous souhaitez supprimer définitivement votre compte rendez-vous sur : https://sip.linphone.org</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Se desideri eliminare definitivamente il tuo account, vai su: https://subscribe.linphone.org</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="131"/>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="280"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="131" />
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="280" />
         <source>error</source>
         <extracomment>Erreur</extracomment>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="318"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="318" />
         <source>manage_account_device_remove</source>
-        <extracomment>&quot;Supprimer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer"</extracomment>
+        <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="327"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="327" />
         <source>manage_account_device_remove_confirm_dialog</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminare %1?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="341"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="341" />
         <source>manage_account_device_last_connection</source>
-        <extracomment>&quot;Dernière connexion:&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Dernière connexion:"</extracomment>
+        <translation>Ultimo accesso:</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="359"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsGeneralLayout.qml" line="359" />
         <source>device_last_updated_time_no_info</source>
-        <extracomment>&quot;No information&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"No information"</extracomment>
+        <translation>Nessuna informazione</translation>
     </message>
 </context>
 <context>
     <name>AccountSettingsPage</name>
     <message>
-        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="13"/>
+        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="13" />
         <source>drawer_menu_manage_account</source>
-        <extracomment>&quot;Mon compte&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Mon compte"</extracomment>
+        <translation>Il mio account</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="18"/>
+        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="18" />
         <source>settings_general_title</source>
-        <extracomment>&quot;Général&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Général"</extracomment>
+        <translation>Generale</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="20"/>
+        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="20" />
         <source>settings_account_title</source>
-        <extracomment>&quot;Paramètres de compte&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Paramètres de compte"</extracomment>
+        <translation>Impostazioni account</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="28"/>
+        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="28" />
         <source>contact_editor_popup_abort_confirmation_title</source>
-        <extracomment>&quot;Modifications non enregistrées&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Modifications non enregistrées"</extracomment>
+        <translation>Modifiche non salvate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="30"/>
+        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="30" />
         <source>contact_editor_popup_abort_confirmation_message</source>
-        <extracomment>&quot;Vous avez des modifications non enregistrées. Si vous quittez cette page, vos changements seront perdus. Voulez-vous enregistrer vos modifications avant de continuer ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vous avez des modifications non enregistrées. Si vous quittez cette page, vos changements seront perdus. Voulez-vous enregistrer vos modifications avant de continuer ?"</extracomment>
+        <translation>Ci sono modifiche non salvate. Se esci da questa pagina, le modifiche andranno perse. Vuoi salvarle prima di continuare?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="41"/>
+        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="41" />
         <source>contact_editor_dialog_abort_confirmation_do_not_save</source>
-        <extracomment>&quot;Ne pas enregistrer&quot; &quot;Enregistrer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ne pas enregistrer" "Enregistrer"</extracomment>
+        <translation>Non salvare</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="41"/>
+        <location filename="../../view/Page/Form/Settings/AccountSettingsPage.qml" line="41" />
         <source>contact_editor_dialog_abort_confirmation_save</source>
         <translation>Salvare</translation>
     </message>
@@ -400,1682 +400,1684 @@
 <context>
     <name>AccountSettingsParametersLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="18"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="18" />
         <source>settings_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="22"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="22" />
         <source>settings_account_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Impostazioni account</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="39"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="39" />
         <source>information_popup_success_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Operazione riuscita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="41"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="41" />
         <source>contact_editor_saved_changes_toast</source>
-        <extracomment>&quot;Modifications sauvegardés&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Modifications sauvegardés"</extracomment>
+        <translation>Modifiche salvate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="47"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="47" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="65"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="65" />
         <source>account_settings_mwi_uri_title</source>
-        <extracomment>&quot;MWI server address&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"MWI server address"</extracomment>
+        <translation>URI del server di segreteria</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="68"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="68" />
         <source>mwi_server_address_tooltip</source>
         <extracomment>Address of the MWI server that sends SIP notifications to display new voicemail indicators</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Indirizzo del server MWI che invia le notifiche SIP per mostrare i nuovi messaggi in segreteria</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="88"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="88" />
         <source>account_settings_voicemail_uri_title</source>
-        <extracomment>&quot;Voicemail address&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Voicemail address"</extracomment>
+        <translation>URI della segreteria</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="90"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="90" />
         <source>voicemail_address_tooltip</source>
         <extracomment>SIP address dialed when clicking the voicemail button</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Indirizzo SIP chiamato premendo il pulsante segreteria</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="117"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="117" />
         <source>account_settings_registrar_uri_title</source>
-        <translation type="unfinished"></translation>
+        <translation>URI registrar</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="134"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="134" />
         <source>account_settings_sip_proxy_url_title</source>
-        <translation type="unfinished"></translation>
+        <translation>URI proxy SIP in uscita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="138"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="138" />
         <source>login_proxy_server_url_tooltip</source>
-        <extracomment>&quot;If this field is filled, the outbound proxy will be enabled automatically. Leave it empty to disable it.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"If this field is filled, the outbound proxy will be enabled automatically. Leave it empty to disable it."</extracomment>
+        <translation>Se questo campo è compilato, il proxy in uscita verrà abilitato automaticamente. Lascialo vuoto per disabilitarlo.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="155"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="155" />
         <source>account_settings_stun_server_url_title</source>
-        <extracomment>&quot;Adresse du serveur STUN&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Adresse du serveur STUN"</extracomment>
+        <translation>Indirizzo del server STUN</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="169"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="169" />
         <source>account_settings_enable_ice_title</source>
-        <extracomment>&quot;Activer ICE&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Activer ICE"</extracomment>
+        <translation>Abilita ICE</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="184"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="184" />
         <source>account_settings_avpf_title</source>
-        <extracomment>&quot;AVPF&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"AVPF"</extracomment>
+        <translation>AVPF</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="199"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="199" />
         <source>account_settings_bundle_mode_title</source>
-        <extracomment>&quot;Mode bundle&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Mode bundle"</extracomment>
+        <translation>Modalità bundle</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="217"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="217" />
         <source>account_settings_expire_title</source>
-        <extracomment>&quot;Expiration (en seconde)&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Expiration (en seconde)"</extracomment>
+        <translation>Scadenza (in secondi)</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="235"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="235" />
         <source>account_settings_conference_factory_uri_title</source>
-        <extracomment>&quot;URI du serveur de conversations&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"URI du serveur de conversations"</extracomment>
+        <translation>URI del server di conferenza</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="252"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="252" />
         <source>account_settings_audio_video_conference_factory_uri_title</source>
-        <extracomment>&quot;URI du serveur de réunions&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"URI du serveur de réunions"</extracomment>
+        <translation>URI del server di videoconferenza</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="267"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="267" />
         <source>account_settings_lime_server_url_title</source>
-        <extracomment>&quot;URL du serveur d’échange de clés de chiffrement&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"URL du serveur d’échange de clés de chiffrement"</extracomment>
+        <translation>URL del server Lime</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="282"/>
+        <location filename="../../view/Page/Layout/Settings/AccountSettingsParametersLayout.qml" line="282" />
         <source>account_settings_ccmp_server_url_title</source>
-        <extracomment>&quot;URL du serveur CCMP&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"URL du serveur CCMP"</extracomment>
+        <translation>URL del server CCMP</translation>
     </message>
 </context>
 <context>
     <name>AddParticipantsForm</name>
     <message>
-        <location filename="../../view/Page/Form/Meeting/AddParticipantsForm.qml" line="14"/>
+        <location filename="../../view/Page/Form/Meeting/AddParticipantsForm.qml" line="14" />
         <source>search_bar_search_contacts_placeholder</source>
-        <extracomment>&quot;Rechercher des contacts&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Rechercher des contacts"</extracomment>
+        <translation>Cerca contatti</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../view/Page/Form/Meeting/AddParticipantsForm.qml" line="56"/>
+        <location filename="../../view/Page/Form/Meeting/AddParticipantsForm.qml" line="56" />
         <source>add_participant_selected_count</source>
         <comment>0</comment>
-        <extracomment>&quot;%n participant(s) sélectionné(s)&quot;</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <extracomment>"%n participant(s) sélectionné(s)"</extracomment>
+        <translation>%1 partecipante selezionato
+%1 partecipanti selezionati<numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/AddParticipantsForm.qml" line="95"/>
+        <location filename="../../view/Page/Form/Meeting/AddParticipantsForm.qml" line="95" />
         <source>remove_participant_accessible_name</source>
         <extracomment>Remove participant %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Rimuovi il partecipante %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/AddParticipantsForm.qml" line="151"/>
+        <location filename="../../view/Page/Form/Meeting/AddParticipantsForm.qml" line="151" />
         <source>list_filter_no_result_found</source>
-        <extracomment>&quot;Aucun contact&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucun contact"</extracomment>
+        <translation>Nessun risultato…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/AddParticipantsForm.qml" line="151"/>
+        <location filename="../../view/Page/Form/Meeting/AddParticipantsForm.qml" line="151" />
         <source>contact_list_empty</source>
-        <translation type="unfinished"></translation>
+        <translation>Nessun contatto al momento</translation>
     </message>
 </context>
 <context>
     <name>AdvancedSettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="16"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="16" />
         <source>settings_system_title</source>
         <extracomment>System</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="22"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="22" />
         <source>settings_remote_provisioning_title</source>
         <extracomment>Remote provisioning</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Provisioning remoto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="29"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="29" />
         <source>settings_security_title</source>
         <extracomment>Security / Encryption</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Sicurezza / Crittografia</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="35"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="35" />
         <source>settings_advanced_audio_codecs_title</source>
         <extracomment>Audio codecs</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Codec audio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="41"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="41" />
         <source>settings_advanced_video_codecs_title</source>
         <extracomment>Video codecs</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Codec video</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="67"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="67" />
         <source>settings_advanced_auto_start_title</source>
         <extracomment>Auto start %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Avvio automatico di %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="85"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="85" />
         <source>settings_advanced_remote_provisioning_url</source>
         <extracomment>Remote provisioning URL</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>URL provisioning remoto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="92"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="92" />
         <source>settings_advanced_download_apply_remote_provisioning</source>
         <extracomment>Download and apply</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Scarica e applica</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="99"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="99" />
         <source>information_popup_error_title</source>
         <extracomment>Invalid URL format</extracomment>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="99"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="99" />
         <source>settings_advanced_invalid_url_message</source>
-        <translation type="unfinished"></translation>
+        <translation>Formato URL non valido</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="102"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="102" />
         <source>download_apply_remote_provisioning_accessible_name</source>
-        <extracomment>&quot;Download and apply remote provisioning&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Download and apply remote provisioning"</extracomment>
+        <translation>Scarica e applica il provisioning remoto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="115"/>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="128"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="115" />
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="128" />
         <source>settings_advanced_media_encryption_title</source>
         <extracomment>Media encryption</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Crittografia media</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="134"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="134" />
         <source>settings_advanced_media_encryption_mandatory_title</source>
         <extracomment>Media encryption mandatory</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Crittografia media obbligatoria</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="142"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="142" />
         <source>settings_advanced_create_endtoend_encrypted_meetings_title</source>
         <extracomment>Create end to end encrypted meetings and group calls</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Crea riunioni e chiamate di gruppo con crittografia end-to-end</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="263"/>
+        <location filename="../../view/Page/Layout/Settings/AdvancedSettingsLayout.qml" line="263" />
         <source>settings_advanced_hide_fps_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Nascondi FPS</translation>
     </message>
 </context>
 <context>
     <name>AllContactListView</name>
     <message>
-        <location filename="../../view/Control/Display/Contact/AllContactListView.qml" line="290"/>
+        <location filename="../../view/Control/Display/Contact/AllContactListView.qml" line="290" />
         <source>car_favorites_contacts_title</source>
-        <extracomment>&quot;Favoris&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Favoris"</extracomment>
+        <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/AllContactListView.qml" line="338"/>
+        <location filename="../../view/Control/Display/Contact/AllContactListView.qml" line="338" />
         <source>generic_address_picker_contacts_list_title</source>
-        <extracomment>&apos;Contacts&apos;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>'Contacts'</extracomment>
+        <translation>Contatti</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/AllContactListView.qml" line="388"/>
+        <location filename="../../view/Control/Display/Contact/AllContactListView.qml" line="388" />
         <source>generic_address_picker_suggestions_list_title</source>
-        <extracomment>&quot;Suggestions&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Suggestions"</extracomment>
+        <translation>Suggerimenti</translation>
     </message>
 </context>
 <context>
     <name>App</name>
     <message>
-        <location filename="../../core/App.cpp" line="381"/>
+        <location filename="../../core/App.cpp" line="381" />
         <source>remote_provisioning_dialog</source>
         <extracomment>Voulez-vous télécharger et appliquer la configuration depuis cette adresse ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Vuoi scaricare e applicare la configurazione da questo indirizzo?</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="443"/>
-        <location filename="../../core/App.cpp" line="451"/>
-        <location filename="../../core/App.cpp" line="455"/>
-        <location filename="../../core/App.cpp" line="533"/>
-        <location filename="../../core/App.cpp" line="856"/>
+        <location filename="../../core/App.cpp" line="443" />
+        <location filename="../../core/App.cpp" line="451" />
+        <location filename="../../core/App.cpp" line="455" />
+        <location filename="../../core/App.cpp" line="533" />
+        <location filename="../../core/App.cpp" line="856" />
         <source>info_popup_error_title</source>
         <extracomment>Error</extracomment>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="444"/>
-        <location filename="../../core/App.cpp" line="858"/>
+        <location filename="../../core/App.cpp" line="444" />
+        <location filename="../../core/App.cpp" line="858" />
         <source>info_popup_configuration_failed_message</source>
         <extracomment>Remote provisioning failed : %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Provisioning remoto non riuscito: %1</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="536"/>
+        <location filename="../../core/App.cpp" line="536" />
         <source>info_popup_error_checking_update</source>
         <extracomment>An error occured while trying to check update. Please try again later or contact support team.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Si è verificato un errore durante il controllo degli aggiornamenti. Riprova più tardi o contatta l'assistenza.</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="543"/>
+        <location filename="../../core/App.cpp" line="543" />
         <source>info_popup_new_version_download_label</source>
         <extracomment>Download it !</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Scaricalo!</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="546"/>
+        <location filename="../../core/App.cpp" line="546" />
         <source>info_popup_new_version_available_title</source>
         <extracomment>New version available !</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nuova versione disponibile!</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="548"/>
+        <location filename="../../core/App.cpp" line="548" />
         <source>info_popup_new_version_available_message</source>
         <extracomment>A new version of Linphone (%1) is available. %2</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>È disponibile una nuova versione di Linphone (%1) su %1</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="556"/>
+        <location filename="../../core/App.cpp" line="556" />
         <source>info_popup_version_up_to_date_title</source>
         <extracomment>Up to date</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Aggiornato</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="558"/>
+        <location filename="../../core/App.cpp" line="558" />
         <source>info_popup_version_up_to_date_message</source>
         <extracomment>Your version is up to date</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Aggiornato La tua versione è aggiornata</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="852"/>
+        <location filename="../../core/App.cpp" line="852" />
         <source>configuration_error_detail</source>
         <extracomment>not reachable</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>non raggiungibile</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1155"/>
+        <location filename="../../core/App.cpp" line="1155" />
         <source>application_description</source>
-        <extracomment>&quot;A free and open source SIP video-phone.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"A free and open source SIP video-phone."</extracomment>
+        <translation>Un videofono SIP gratuito e open source.</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1157"/>
+        <location filename="../../core/App.cpp" line="1157" />
         <source>command_line_arg_order</source>
-        <extracomment>&quot;Send an order to the application towards a command line&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Send an order to the application towards a command line"</extracomment>
+        <translation>Invia un comando all'applicazione da riga di comando</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1161"/>
+        <location filename="../../core/App.cpp" line="1161" />
         <source>command_line_option_show_help</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostra questa guida</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1166"/>
+        <location filename="../../core/App.cpp" line="1166" />
         <source>command_line_option_show_app_version</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostra la versione dell'app</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1174"/>
+        <location filename="../../core/App.cpp" line="1174" />
         <source>command_line_option_config_to_fetch</source>
-        <extracomment>&quot;Specify the linphone configuration file to be fetched. It will be merged with the current configuration.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Specify the linphone configuration file to be fetched. It will be merged with the current configuration."</extracomment>
+        <translation>Specifica il file di configurazione di linphone da recuperare. Verrà unito alla configurazione attuale.</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1176"/>
+        <location filename="../../core/App.cpp" line="1176" />
         <source>command_line_option_config_to_fetch_arg</source>
-        <extracomment>&quot;URL, path or file&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"URL, path or file"</extracomment>
+        <translation>URL, percorso o file</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1181"/>
+        <location filename="../../core/App.cpp" line="1181" />
         <source>command_line_option_minimized</source>
-        <translation type="unfinished"></translation>
+        <translation>Riduci a icona</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1184"/>
+        <location filename="../../core/App.cpp" line="1184" />
         <source>command_line_option_log_to_stdout</source>
-        <translation type="unfinished"></translation>
+        <translation>Registra su stdout alcune informazioni di debug durante l'esecuzione</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1187"/>
+        <location filename="../../core/App.cpp" line="1187" />
         <source>command_line_option_print_app_logs_only</source>
-        <extracomment>&quot;Print only logs from the application&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Print only logs from the application"</extracomment>
+        <translation>Stampa solo i log dell'applicazione</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1655"/>
+        <location filename="../../core/App.cpp" line="1655" />
         <source>hide_action</source>
-        <extracomment>&quot;Cacher&quot; &quot;Afficher&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Cacher" "Afficher"</extracomment>
+        <translation>Nascondi</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1655"/>
+        <location filename="../../core/App.cpp" line="1655" />
         <source>show_action</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostra</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1670"/>
+        <location filename="../../core/App.cpp" line="1670" />
         <source>quit_action</source>
-        <extracomment>&quot;Quitter&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Quitter"</extracomment>
+        <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1688"/>
+        <location filename="../../core/App.cpp" line="1688" />
         <source>check_for_update</source>
         <extracomment>Check for update</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Verifica aggiornamenti</translation>
     </message>
     <message>
-        <location filename="../../core/App.cpp" line="1837"/>
+        <location filename="../../core/App.cpp" line="1837" />
         <source>mark_all_read_action</source>
-        <translation type="unfinished"></translation>
+        <translation>Segna tutto come letto</translation>
     </message>
 </context>
 <context>
     <name>AuthenticationDialog</name>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="50"/>
+        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="50" />
         <source>account_settings_dialog_invalid_password_title</source>
-        <extracomment>&quot;Authentification requise&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Authentification requise"</extracomment>
+        <translation>Autenticazione richiesta</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="59"/>
+        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="59" />
         <source>account_settings_dialog_invalid_password_message</source>
         <extracomment>La connexion a échoué pour le compte %1. Vous pouvez renseigner votre mot de passe à nouveau ou bien vérifier les options de configuration de votre compte.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Accesso non riuscito per l'account %1. Puoi inserire di nuovo la password oppure controllare le impostazioni del tuo account.</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="69"/>
+        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="69" />
         <source>password</source>
-        <translation type="unfinished"></translation>
+        <translation>Password</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="87"/>
+        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="87" />
         <source>cancel</source>
-        <extracomment>&quot;Annuler</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Annuler</extracomment>
+        <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="97"/>
+        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="97" />
         <source>assistant_account_login</source>
         <extracomment>Connexion</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Connessione</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="105"/>
+        <location filename="../../view/Control/Popup/Dialog/AuthenticationDialog.qml" line="105" />
         <source>assistant_account_login_missing_password</source>
         <extracomment>Veuillez saisir un mot de passe</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci una password</translation>
     </message>
 </context>
 <context>
     <name>CallCore</name>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="223"/>
+        <location filename="../../core/call/CallCore.cpp" line="223" />
         <source>call_record_end_message</source>
-        <extracomment>&quot;Enregistrement terminé&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Enregistrement terminé"</extracomment>
+        <translation>Registrazione terminata</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="225"/>
+        <location filename="../../core/call/CallCore.cpp" line="225" />
         <source>call_record_saved_in_file_message</source>
-        <extracomment>&quot;L&apos;appel a été enregistré dans le fichier : %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"L'appel a été enregistré dans le fichier : %1"</extracomment>
+        <translation>La chiamata è stata salvata nel file: %1</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="421"/>
-        <location filename="../../core/call/CallCore.cpp" line="446"/>
+        <location filename="../../core/call/CallCore.cpp" line="421" />
+        <location filename="../../core/call/CallCore.cpp" line="446" />
         <source>call_stats_codec_label</source>
-        <extracomment>&quot;Codec: %1 / %2 kHz&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Codec: %1 / %2 kHz"</extracomment>
+        <translation>Codec: %1 / %2 kHz</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="425"/>
-        <location filename="../../core/call/CallCore.cpp" line="449"/>
+        <location filename="../../core/call/CallCore.cpp" line="425" />
+        <location filename="../../core/call/CallCore.cpp" line="449" />
         <source>call_stats_bandwidth_label</source>
-        <extracomment>&quot;Bande passante : %1 %2 kbits/s %3 %4 kbits/s&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Bande passante : %1 %2 kbits/s %3 %4 kbits/s"</extracomment>
+        <translation>Larghezza di banda: %1 %2 kbit/s %3 %4 kbit/s</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="431"/>
-        <location filename="../../core/call/CallCore.cpp" line="454"/>
+        <location filename="../../core/call/CallCore.cpp" line="431" />
+        <location filename="../../core/call/CallCore.cpp" line="454" />
         <source>call_stats_loss_rate_label</source>
-        <extracomment>&quot;Taux de perte: %1% %2%&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Taux de perte: %1% %2%"</extracomment>
+        <translation>Tasso di perdita: %1% %2%</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="436"/>
+        <location filename="../../core/call/CallCore.cpp" line="436" />
         <source>call_stats_jitter_buffer_label</source>
-        <extracomment>&quot;Tampon de gigue: %1 ms&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Tampon de gigue: %1 ms"</extracomment>
+        <translation>Buffer di jitter: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="463"/>
+        <location filename="../../core/call/CallCore.cpp" line="463" />
         <source>call_stats_resolution_label</source>
-        <extracomment>&quot;Définition vidéo : %1 %2 %3 %4&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Définition vidéo : %1 %2 %3 %4"</extracomment>
+        <translation>Risoluzione video: %1 %2 %3 %4</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="469"/>
+        <location filename="../../core/call/CallCore.cpp" line="469" />
         <source>call_stats_fps_label</source>
-        <extracomment>&quot;FPS : %1 %2 %3 %4&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"FPS : %1 %2 %3 %4"</extracomment>
+        <translation>FPS: %1 %2 %3 %4</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="747"/>
+        <location filename="../../core/call/CallCore.cpp" line="747" />
         <source>media_encryption_dtls</source>
         <extracomment>DTLS</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>DTLS</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="750"/>
+        <location filename="../../core/call/CallCore.cpp" line="750" />
         <source>media_encryption_none</source>
         <extracomment>None</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nessuna</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="753"/>
+        <location filename="../../core/call/CallCore.cpp" line="753" />
         <source>media_encryption_srtp</source>
         <extracomment>SRTP</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>SRTP</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallCore.cpp" line="756"/>
+        <location filename="../../core/call/CallCore.cpp" line="756" />
         <source>media_encryption_post_quantum</source>
-        <extracomment>&quot;ZRTP - Post quantique&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"ZRTP - Post quantique"</extracomment>
+        <translation>ZRTP post-quantistico</translation>
     </message>
 </context>
 <context>
     <name>CallForwardSettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="42"/>
+        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="42" />
         <source>settings_call_forward_activate_title</source>
-        <extracomment>&quot;Forward calls&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Forward calls"</extracomment>
+        <translation>Inoltra chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="44"/>
+        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="44" />
         <source>settings_call_forward_activate_subtitle</source>
-        <extracomment>&quot;Enable call forwarding to voicemail or sip address&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Enable call forwarding to voicemail or sip address"</extracomment>
+        <translation>Attiva l'inoltro delle chiamate verso la segreteria o un indirizzo SIP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="56"/>
-        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="97"/>
+        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="56" />
+        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="97" />
         <source>settings_call_forward_destination_choose</source>
         <extracomment>Forward to destination</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Inoltra le chiamate a:</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="68"/>
+        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="68" />
         <source>settings_call_forward_to_voicemail</source>
-        <translation type="unfinished"></translation>
+        <translation>Segreteria telefonica</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="69"/>
+        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="69" />
         <source>settings_call_forward_to_sipaddress</source>
-        <translation type="unfinished"></translation>
+        <translation>Numero / indirizzo SIP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="106"/>
+        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="106" />
         <source>settings_call_forward_sipaddress_title</source>
         <extracomment>SIP Address</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Numero / indirizzo SIP:</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="107"/>
+        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="107" />
         <source>settings_call_forward_sipaddress_placeholder</source>
-        <translation type="unfinished"></translation>
+        <translation>Mario.rossi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="26"/>
+        <location filename="../../view/Page/Layout/Settings/CallForwardSettingsLayout.qml" line="26" />
         <source>settings_call_forward_address_cannot_be_empty</source>
-        <translation type="unfinished"></translation>
+        <translation>Un numero o un indirizzo SIP è obbligatorio</translation>
     </message>
 </context>
 <context>
     <name>CallHistoryLayout</name>
     <message>
-        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="116"/>
-        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="140"/>
+        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="116" />
+        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="140" />
         <source>meeting_info_join_title</source>
-        <extracomment>&quot;Rejoindre la réunion&quot;
+        <extracomment>"Rejoindre la réunion"
 ----------
-&quot;Join&quot;</extracomment>
-        <translation type="unfinished"></translation>
+"Join"</extracomment>
+        <translation>Partecipa alla riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="155"/>
+        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="155" />
         <source>contact_conversation_action</source>
-        <extracomment>&quot;Conversation&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Conversation"</extracomment>
+        <translation>Conversazione</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="174"/>
+        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="174" />
         <source>contact_call_action</source>
-        <extracomment>&quot;Appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel"</extracomment>
+        <translation>Chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="188"/>
+        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="188" />
         <source>contact_message_action</source>
-        <extracomment>&quot;Message&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Message"</extracomment>
+        <translation>Messaggio</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="208"/>
+        <location filename="../../view/Control/Container/Call/CallHistoryLayout.qml" line="208" />
         <source>contact_video_call_action</source>
-        <extracomment>&quot;Appel Video&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel Video"</extracomment>
+        <translation>Videochiamata</translation>
     </message>
 </context>
 <context>
     <name>CallHistoryListView</name>
     <message>
-        <location filename="../../view/Control/Display/Call/CallHistoryListView.qml" line="226"/>
+        <location filename="../../view/Control/Display/Call/CallHistoryListView.qml" line="226" />
         <source>call_name_accessible_button</source>
         <extracomment>Call %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiama %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallHistoryListView.qml" line="260"/>
+        <location filename="../../view/Control/Display/Call/CallHistoryListView.qml" line="260" />
         <source>call_history_entry_accessible_name</source>
         <extracomment>%1 - %2 - %3 - right arrow for call-back button</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>%1 - %2 - %3 - freccia destra per richiamare</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallHistoryListView.qml" line="262"/>
+        <location filename="../../view/Control/Display/Call/CallHistoryListView.qml" line="262" />
         <source>notification_missed_call_title</source>
-        <extracomment>&quot;Appel manqué&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel manqué"</extracomment>
+        <translation>Chiamata persa</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallHistoryListView.qml" line="264"/>
+        <location filename="../../view/Control/Display/Call/CallHistoryListView.qml" line="264" />
         <source>call_outgoing</source>
-        <extracomment>&quot;Appel sortant&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel sortant"</extracomment>
+        <translation>Chiamata in uscita</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallHistoryListView.qml" line="266"/>
+        <location filename="../../view/Control/Display/Call/CallHistoryListView.qml" line="266" />
         <source>call_audio_incoming</source>
-        <extracomment>&quot;Appel entrant&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel entrant"</extracomment>
+        <translation>Chiamata in arrivo</translation>
     </message>
 </context>
 <context>
     <name>CallLayout</name>
     <message>
-        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="79"/>
+        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="79" />
         <source>meeting_event_conference_destroyed</source>
-        <extracomment>&quot;Vous avez quitté la conférence&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vous avez quitté la conférence"</extracomment>
+        <translation>Hai lasciato la riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="82"/>
+        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="82" />
         <source>call_ended_by_user</source>
-        <extracomment>&quot;Vous avez terminé l&apos;appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vous avez terminé l'appel"</extracomment>
+        <translation>Hai terminato la chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="85"/>
+        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="85" />
         <source>call_ended_by_remote</source>
-        <extracomment>&quot;Votre correspondant a terminé l&apos;appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Votre correspondant a terminé l'appel"</extracomment>
+        <translation>Il tuo interlocutore ha terminato la chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="160"/>
+        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="160" />
         <source>conference_call_empty</source>
-        <extracomment>&quot;En attente d&apos;autres participants…&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"En attente d'autres participants…"</extracomment>
+        <translation>In attesa di altri partecipanti…</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="178"/>
+        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="178" />
         <source>conference_share_link_title</source>
-        <extracomment>&quot;Partager le lien&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Partager le lien"</extracomment>
+        <translation>Condividi link</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="184"/>
+        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="184" />
         <source>copied</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiato</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="186"/>
+        <location filename="../../view/Control/Container/Call/CallLayout.qml" line="186" />
         <source>information_popup_meeting_address_copied_to_clipboard</source>
         <extracomment>Le lien de la réunion a été copié dans le presse-papier</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Il link della riunione è stato copiato negli appunti</translation>
     </message>
 </context>
 <context>
     <name>CallList</name>
     <message>
-        <location filename="../../core/call/CallList.cpp" line="104"/>
+        <location filename="../../core/call/CallList.cpp" line="104" />
         <source>remote_group_call</source>
         <extracomment>Remote group call</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiamata di gruppo remota</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallList.cpp" line="106"/>
+        <location filename="../../core/call/CallList.cpp" line="106" />
         <source>local_group_call</source>
-        <extracomment>&quot;Local group call&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Local group call"</extracomment>
+        <translation>Chiamata di gruppo locale</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallList.cpp" line="111"/>
+        <location filename="../../core/call/CallList.cpp" line="111" />
         <source>info_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../core/call/CallList.cpp" line="113"/>
+        <location filename="../../core/call/CallList.cpp" line="113" />
         <source>info_popup_merge_calls_failed_message</source>
         <extracomment>Failed to merge calls !</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile unire le chiamate!</translation>
     </message>
 </context>
 <context>
     <name>CallListView</name>
     <message>
-        <location filename="../../view/Control/Display/Call/CallListView.qml" line="62"/>
+        <location filename="../../view/Control/Display/Call/CallListView.qml" line="62" />
         <source>meeting</source>
-        <extracomment>&quot;Réunion</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Réunion</extracomment>
+        <translation>Riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallListView.qml" line="64"/>
+        <location filename="../../view/Control/Display/Call/CallListView.qml" line="64" />
         <source>call</source>
-        <extracomment>&quot;Appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel"</extracomment>
+        <translation>Chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallListView.qml" line="69"/>
+        <location filename="../../view/Control/Display/Call/CallListView.qml" line="69" />
         <source>paused_call_or_meeting</source>
-        <extracomment>&quot;%1 en pause&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"%1 en pause"</extracomment>
+        <translation>%1 in pausa</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallListView.qml" line="71"/>
+        <location filename="../../view/Control/Display/Call/CallListView.qml" line="71" />
         <source>ongoing_call_or_meeting</source>
-        <extracomment>&quot;%1 en cours&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"%1 en cours"</extracomment>
+        <translation>%1 in corso</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallListView.qml" line="99"/>
+        <location filename="../../view/Control/Display/Call/CallListView.qml" line="99" />
         <source>transfer_call_name_accessible_name</source>
         <extracomment>Transfer call %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Trasferisci chiamata %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallListView.qml" line="127"/>
+        <location filename="../../view/Control/Display/Call/CallListView.qml" line="127" />
         <source>resume_call_name_accessible_name</source>
         <extracomment>Resume %1 call</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Riprendi chiamata %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallListView.qml" line="129"/>
+        <location filename="../../view/Control/Display/Call/CallListView.qml" line="129" />
         <source>pause_call_name_accessible_name</source>
         <extracomment>Pause %1 call</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Metti in pausa chiamata %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallListView.qml" line="152"/>
+        <location filename="../../view/Control/Display/Call/CallListView.qml" line="152" />
         <source>end_call_name_accessible_name</source>
         <extracomment>End %1 call</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Termina chiamata %1</translation>
     </message>
 </context>
 <context>
     <name>CallModel</name>
     <message>
-        <location filename="../../model/call/CallModel.cpp" line="389"/>
+        <location filename="../../model/call/CallModel.cpp" line="389" />
         <source>call_error_no_response_toast</source>
-        <extracomment>&quot;No response&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"No response"</extracomment>
+        <translation>Nessuna risposta</translation>
     </message>
     <message>
-        <location filename="../../model/call/CallModel.cpp" line="393"/>
+        <location filename="../../model/call/CallModel.cpp" line="393" />
         <source>call_error_forbidden_resource_toast</source>
-        <extracomment>&quot;403 : Forbidden resource&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"403 : Forbidden resource"</extracomment>
+        <translation>403: risorsa non consentita</translation>
     </message>
     <message>
-        <location filename="../../model/call/CallModel.cpp" line="397"/>
+        <location filename="../../model/call/CallModel.cpp" line="397" />
         <source>call_error_not_answered_toast</source>
-        <extracomment>&quot;Request timeout&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Request timeout"</extracomment>
+        <translation>Tempo scaduto per la richiesta</translation>
     </message>
     <message>
-        <location filename="../../model/call/CallModel.cpp" line="401"/>
+        <location filename="../../model/call/CallModel.cpp" line="401" />
         <source>call_error_user_declined_toast</source>
-        <extracomment>&quot;User declined the call&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"User declined the call"</extracomment>
+        <translation>L'utente ha rifiutato la chiamata</translation>
     </message>
     <message>
-        <location filename="../../model/call/CallModel.cpp" line="405"/>
+        <location filename="../../model/call/CallModel.cpp" line="405" />
         <source>call_error_user_not_found_toast</source>
-        <extracomment>&quot;User was not found&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"User was not found"</extracomment>
+        <translation>Utente non trovato</translation>
     </message>
     <message>
-        <location filename="../../model/call/CallModel.cpp" line="409"/>
+        <location filename="../../model/call/CallModel.cpp" line="409" />
         <source>call_error_user_busy_toast</source>
-        <extracomment>&quot;User is busy&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"User is busy"</extracomment>
+        <translation>L'utente è occupato</translation>
     </message>
     <message>
-        <location filename="../../model/call/CallModel.cpp" line="413"/>
+        <location filename="../../model/call/CallModel.cpp" line="413" />
         <source>call_error_incompatible_media_params_toast</source>
-        <extracomment>&quot;User can&amp;apos;t accept your call&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"User can&amp;apos;t accept your call"</extracomment>
+        <translation>L'utente non può accettare la tua chiamata</translation>
     </message>
     <message>
-        <location filename="../../model/call/CallModel.cpp" line="417"/>
+        <location filename="../../model/call/CallModel.cpp" line="417" />
         <source>call_error_io_error_toast</source>
-        <extracomment>&quot;Unavailable service or network error&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Unavailable service or network error"</extracomment>
+        <translation>Servizio non disponibile o errore di rete</translation>
     </message>
     <message>
-        <location filename="../../model/call/CallModel.cpp" line="421"/>
+        <location filename="../../model/call/CallModel.cpp" line="421" />
         <source>call_error_do_not_disturb_toast</source>
-        <extracomment>&quot;Le correspondant ne peut être dérangé&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le correspondant ne peut être dérangé"</extracomment>
+        <translation>L'utente non può essere disturbato</translation>
     </message>
     <message>
-        <location filename="../../model/call/CallModel.cpp" line="425"/>
+        <location filename="../../model/call/CallModel.cpp" line="425" />
         <source>call_error_temporarily_unavailable_toast</source>
-        <extracomment>&quot;Temporarily unavailable&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Temporarily unavailable"</extracomment>
+        <translation>Temporaneamente non disponibile</translation>
     </message>
     <message>
-        <location filename="../../model/call/CallModel.cpp" line="429"/>
+        <location filename="../../model/call/CallModel.cpp" line="429" />
         <source>call_error_server_timeout_toast</source>
-        <extracomment>&quot;Server timeout&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Server timeout"</extracomment>
+        <translation>Timeout del server</translation>
     </message>
 </context>
 <context>
     <name>CallPage</name>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="249"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="249" />
         <source>call_forward_to_address_info</source>
-        <translation type="unfinished"></translation>
+        <translation>Inoltra le chiamate a: </translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="249"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="249" />
         <source>call_forward_to_address_info_voicemail</source>
-        <translation type="unfinished"></translation>
+        <translation>Segreteria telefonica</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="14"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="14" />
         <source>history_call_start_title</source>
-        <extracomment>&quot;Nouvel appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nouvel appel"</extracomment>
+        <translation>Nuova chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="16"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="16" />
         <source>call_history_empty_title</source>
-        <extracomment>&quot;Historique d&apos;appel vide&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Historique d'appel vide"</extracomment>
+        <translation>Cronologia chiamate vuota</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="92"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="92" />
         <source>history_dialog_delete_all_call_logs_title</source>
-        <extracomment>Supprimer l&apos;historique d&apos;appels ?</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>Supprimer l'historique d'appels ?</extracomment>
+        <translation>Eliminare la cronologia chiamate?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="94"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="94" />
         <source>history_dialog_delete_all_call_logs_message</source>
-        <extracomment>&quot;L&apos;ensemble de votre historique d&apos;appels sera définitivement supprimé.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"L'ensemble de votre historique d'appels sera définitivement supprimé."</extracomment>
+        <translation>L'intera cronologia delle chiamate verrà eliminata definitivamente.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="100"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="100" />
         <source>history_dialog_delete_call_logs_title</source>
-        <extracomment>Supprimer l&apos;historique d&apos;appels ?</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>Supprimer l'historique d'appels ?</extracomment>
+        <translation>Eliminare la cronologia chiamate?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="102"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="102" />
         <source>history_dialog_delete_call_logs_message</source>
-        <extracomment>&quot;L&apos;ensemble de votre historique d&apos;appels avec ce correspondant sera définitivement supprimé.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"L'ensemble de votre historique d'appels avec ce correspondant sera définitivement supprimé."</extracomment>
+        <translation>La cronologia delle chiamate con questo utente verrà eliminata definitivamente.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="159"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="159" />
         <source>call_history_call_list_title</source>
-        <extracomment>&quot;Appels&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appels"</extracomment>
+        <translation>Chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="462"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="462" />
         <source>call_history_options_accessible_name</source>
-        <translation type="unfinished"></translation>
+        <translation>Opzioni cronologia chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="180"/>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="554"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="180" />
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="554" />
         <source>menu_delete_history</source>
-        <extracomment>&quot;Supprimer l&apos;historique&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer l'historique"</extracomment>
+        <translation>Elimina cronologia</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="174"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="174" />
         <source>call_history_list_options_accessible_name</source>
         <extracomment>Call history options</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Opzioni cronologia chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="209"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="209" />
         <source>create_new_call_accessible_name</source>
         <extracomment>Create new call</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Crea nuova chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="222"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="222" />
         <source>call_search_in_history</source>
-        <extracomment>&quot;Rechercher un appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Rechercher un appel"</extracomment>
+        <translation>Cerca una chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="277"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="277" />
         <source>list_filter_no_result_found</source>
-        <extracomment>&quot;Aucun résultat…&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucun résultat…"</extracomment>
+        <translation>Nessun risultato…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="279"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="279" />
         <source>history_list_empty_history</source>
-        <extracomment>&quot;Aucun appel dans votre historique&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucun appel dans votre historique"</extracomment>
+        <translation>Nessuna chiamata nella cronologia</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="359"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="359" />
         <source>return_to_call_history_accessible_name</source>
         <extracomment>Return to call history</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Torna alla cronologia chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="370"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="370" />
         <source>call_action_start_new_call</source>
-        <extracomment>&quot;Nouvel appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nouvel appel"</extracomment>
+        <translation>Nuova chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="409"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="409" />
         <source>call_start_group_call_title</source>
-        <extracomment>&quot;Appel de groupe&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel de groupe"</extracomment>
+        <translation>Chiamata di gruppo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="411"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="411" />
         <source>call_action_start_group_call</source>
-        <extracomment>&quot;Lancer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Lancer"</extracomment>
+        <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="421"/>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="425"/>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="523"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="421" />
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="425" />
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="523" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="423"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="423" />
         <source>group_call_error_must_have_name</source>
-        <extracomment>&quot;Un nom doit être donné à l&apos;appel de groupe</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Un nom doit être donné à l'appel de groupe</extracomment>
+        <translation>È necessario indicare un nome per la chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="427"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="427" />
         <source>group_call_error_not_connected</source>
-        <extracomment>&quot;Vous n&apos;etes pas connecté&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vous n'etes pas connecté"</extracomment>
+        <translation>Non sei connesso</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="481"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="481" />
         <source>menu_see_existing_contact</source>
-        <extracomment>&quot;Show contact&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Show contact"</extracomment>
+        <translation>Mostra contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="483"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="483" />
         <source>menu_add_address_to_contacts</source>
-        <extracomment>&quot;Add to contacts&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Add to contacts"</extracomment>
+        <translation>Aggiungi ai contatti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="505"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="505" />
         <source>menu_copy_sip_address</source>
-        <extracomment>&quot;Copier l&apos;adresse SIP&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Copier l'adresse SIP"</extracomment>
+        <translation>Copia indirizzo SIP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="517"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="517" />
         <source>sip_address_copied_to_clipboard_toast</source>
         <extracomment>Adresse copiée</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Indirizzo copiato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="519"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="519" />
         <source>sip_address_copied_to_clipboard_message</source>
-        <extracomment>L&apos;adresse a été copié dans le presse_papiers</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>L'adresse a été copié dans le presse_papiers</extracomment>
+        <translation>L'indirizzo è stato copiato negli appunti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="525"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="525" />
         <source>sip_address_copy_to_clipboard_error</source>
-        <extracomment>&quot;Erreur lors de la copie de l&apos;adresse&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Erreur lors de la copie de l'adresse"</extracomment>
+        <translation>Errore durante la copia dell'indirizzo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="647"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="647" />
         <source>notification_missed_call_title</source>
-        <extracomment>&quot;Appel manqué&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel manqué"</extracomment>
+        <translation>Chiamata persa</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="650"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="650" />
         <source>call_outgoing</source>
-        <extracomment>&quot;Appel sortant&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel sortant"</extracomment>
+        <translation>Chiamata in uscita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/CallPage.qml" line="652"/>
+        <location filename="../../view/Page/Main/Call/CallPage.qml" line="652" />
         <source>call_audio_incoming</source>
-        <extracomment>&quot;Appel entrant&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel entrant"</extracomment>
+        <translation>Chiamata in arrivo</translation>
     </message>
 </context>
 <context>
     <name>CallSettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="23"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="23" />
         <source>settings_call_devices_title</source>
-        <extracomment>&quot;Périphériques&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Périphériques"</extracomment>
+        <translation>Dispositivi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="25"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="25" />
         <source>settings_call_devices_subtitle</source>
-        <extracomment>&quot;Vous pouvez modifier les périphériques de sortie audio, le microphone et la caméra de capture.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vous pouvez modifier les périphériques de sortie audio, le microphone et la caméra de capture."</extracomment>
+        <translation>Puoi modificare i dispositivi di uscita audio, il microfono e la fotocamera.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="54"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="54" />
         <source>settings_calls_echo_canceller_title</source>
-        <extracomment>&quot;Annulateur d&apos;écho&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Annulateur d'écho"</extracomment>
+        <translation>Cancellazione dell'eco</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="56"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="56" />
         <source>settings_calls_echo_canceller_subtitle</source>
-        <extracomment>&quot;Évite que de l&apos;écho soit entendu par votre correspondant&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Évite que de l'écho soit entendu par votre correspondant"</extracomment>
+        <translation>Evita che il tuo interlocutore senta l'eco</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="63"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="63" />
         <source>settings_calls_auto_record_title</source>
-        <extracomment>&quot;Activer l’enregistrement automatique des appels&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Activer l’enregistrement automatique des appels"</extracomment>
+        <translation>Attiva la registrazione automatica delle chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="70"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="70" />
         <source>settings_call_enable_tones_title</source>
         <extracomment>Tonalités</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Toni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="72"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="72" />
         <source>settings_call_enable_tones_subtitle</source>
         <extracomment>Activer les tonalités</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Attiva i toni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="79"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="79" />
         <source>settings_calls_enable_video_title</source>
-        <extracomment>&quot;Autoriser la vidéo&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Autoriser la vidéo"</extracomment>
+        <translation>Attiva video</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="89"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="89" />
         <source>settings_calls_command_line_title</source>
         <extracomment>Command line</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Comando da eseguire alla ricezione di una chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="90"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="90" />
         <source>settings_calls_command_line_title_place_holder</source>
-        <translation type="unfinished"></translation>
+        <translation>comando "https://example.com/?phone=$1&amp;amp;displayName=$2"</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="98"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="98" />
         <source>settings_calls_change_ringtone_title</source>
-        <extracomment>&quot;Change ringtone&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Change ringtone"</extracomment>
+        <translation>Cambia suoneria</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="106"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="106" />
         <source>settings_calls_current_ringtone_filename</source>
         <extracomment>Current ringtone :</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Suoneria attuale:</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="131"/>
+        <location filename="../../view/Page/Layout/Settings/CallSettingsLayout.qml" line="131" />
         <source>choose_ringtone_file_accessible_name</source>
         <extracomment>Choose ringtone file</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Scegli file suoneria</translation>
     </message>
 </context>
 <context>
     <name>CallSettingsPanel</name>
     <message>
-        <location filename="../../view/Page/Main/Call/CallSettingsPanel.qml" line="65"/>
+        <location filename="../../view/Page/Main/Call/CallSettingsPanel.qml" line="65" />
         <source>close_name_panel_accessible_button</source>
         <extracomment>Close %1 panel</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiudi il pannello %1</translation>
     </message>
 </context>
 <context>
     <name>CallStatistics</name>
     <message>
-        <location filename="../../view/Control/Display/Call/CallStatistics.qml" line="30"/>
+        <location filename="../../view/Control/Display/Call/CallStatistics.qml" line="30" />
         <source>call_stats_audio_title</source>
-        <extracomment>&quot;Audio&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Audio"</extracomment>
+        <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Call/CallStatistics.qml" line="92"/>
+        <location filename="../../view/Control/Display/Call/CallStatistics.qml" line="92" />
         <source>call_stats_video_title</source>
-        <extracomment>&quot;Vidéo&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vidéo"</extracomment>
+        <translation>Video</translation>
     </message>
 </context>
 <context>
     <name>CallsWindow</name>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="75"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="75" />
         <source>call_transfer_in_progress_toast</source>
-        <extracomment>&quot;Transfert en cours, veuillez patienter&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Transfert en cours, veuillez patienter"</extracomment>
+        <translation>Trasferimento in corso, attendere</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="84"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="168"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="84" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="168" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="86"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="86" />
         <source>call_transfer_failed_toast</source>
-        <extracomment>&quot;Le transfert d&apos;appel a échoué&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le transfert d'appel a échoué"</extracomment>
+        <translation>Trasferimento non riuscito</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="170"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="170" />
         <source>conference_error_empty_uri</source>
-        <extracomment>&quot;La conférence n&apos;a pas pu démarrer en raison d&apos;une erreur d&apos;uri.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"La conférence n'a pas pu démarrer en raison d'une erreur d'uri."</extracomment>
+        <translation>Impossibile avviare la riunione a causa di un errore URI</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="226"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="226" />
         <source>call_close_window_dialog_title</source>
-        <extracomment>&quot;Terminer tous les appels en cours ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Terminer tous les appels en cours ?"</extracomment>
+        <translation>Terminare tutte le chiamate in corso?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="228"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="228" />
         <source>call_close_window_dialog_message</source>
-        <extracomment>&quot;La fenêtre est sur le point d&apos;être fermée. Cela terminera tous les appels en cours.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"La fenêtre est sur le point d'être fermée. Cela terminera tous les appels en cours."</extracomment>
+        <translation>La finestra sta per essere chiusa. Questo terminerà tutte le chiamate in corso.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="323"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="323" />
         <source>call_can_be_trusted_toast</source>
-        <extracomment>&quot;Appareil authentifié&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appareil authentifié"</extracomment>
+        <translation>Dispositivo attendibile</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="408"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="408" />
         <source>call_dir</source>
-        <translation type="unfinished"></translation>
+        <translation>Chiamata %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="419"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="419" />
         <source>call_ended</source>
         <extracomment>Appel terminé</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiamata terminata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="423"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="423" />
         <source>conference_paused</source>
         <extracomment>Meeting paused</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Riunione in pausa</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="428"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="428" />
         <source>call_paused</source>
         <extracomment>Call paused</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiamata in pausa</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="536"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="536" />
         <source>call_srtp_point_to_point_encrypted</source>
         <extracomment>Appel chiffré de point à point</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiamata cifrata punto a punto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="540"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="540" />
         <source>call_zrtp_sas_validation_required</source>
         <extracomment>Vérification nécessaire</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Verifica necessaria</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="542"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="542" />
         <source>call_zrtp_end_to_end_encrypted</source>
         <extracomment>Appel chiffré de bout en bout</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiamata cifrata end-to-end</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="545"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="545" />
         <source>call_not_encrypted</source>
-        <extracomment>&quot;Appel non chiffré&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel non chiffré"</extracomment>
+        <translation>Chiamata non cifrata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="493"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="546"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="493" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="546" />
         <source>call_waiting_for_encryption_info</source>
         <extracomment>Waiting for encryption</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>In attesa della cifratura</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="426"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="426" />
         <source>call_paused_by_remote</source>
         <extracomment>Call paused by remote</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiamata messa in pausa dal destinatario</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="660"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="660" />
         <source>conference_user_is_recording</source>
-        <extracomment>&quot;You are recording the meeting&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"You are recording the meeting"</extracomment>
+        <translation>Stai registrando la riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="662"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="662" />
         <source>call_user_is_recording</source>
-        <extracomment>&quot;You are recording the call&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"You are recording the call"</extracomment>
+        <translation>Stai registrando la chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="665"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="665" />
         <source>conference_remote_is_recording</source>
-        <extracomment>&quot;Someone is recording the meeting&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Someone is recording the meeting"</extracomment>
+        <translation>Qualcuno sta registrando la riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="667"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="667" />
         <source>call_remote_recording</source>
-        <extracomment>&quot;%1 is recording the call&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"%1 is recording the call"</extracomment>
+        <translation>%1 sta registrando la chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="679"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="679" />
         <source>call_stop_recording</source>
-        <extracomment>&quot;Stop recording&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Stop recording"</extracomment>
+        <translation>Interrompi registrazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="719"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="719" />
         <source>add</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="744"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="744" />
         <source>call_transfer_current_call_title</source>
-        <extracomment>&quot;Transférer %1 à…&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Transférer %1 à…"</extracomment>
+        <translation>Trasferisci %1 a…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="838"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="850"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="838" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="850" />
         <source>call_transfer_confirm_dialog_tittle</source>
-        <extracomment>&quot;Confirmer le transfert&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Confirmer le transfert"</extracomment>
+        <translation>Conferma trasferimento</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="840"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="851"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="840" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="851" />
         <source>call_transfer_confirm_dialog_message</source>
-        <extracomment>&quot;Vous allez transférer %1 à %2.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vous allez transférer %1 à %2."</extracomment>
+        <translation>Stai per trasferire %1 a %2.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="748"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="748" />
         <source>call_action_start_new_call</source>
-        <extracomment>&quot;Nouvel appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nouvel appel"</extracomment>
+        <translation>Nuova chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="752"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1783"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="752" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1783" />
         <source>call_action_show_dialer</source>
-        <extracomment>&quot;Pavé numérique&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Pavé numérique"</extracomment>
+        <translation>Tastierino</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="756"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="756" />
         <source>call_action_change_layout</source>
-        <extracomment>&quot;Modifier la disposition&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Modifier la disposition"</extracomment>
+        <translation>Modifica disposizione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="760"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="760" />
         <source>call_action_go_to_calls_list</source>
-        <extracomment>&quot;Liste d&apos;appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Liste d'appel"</extracomment>
+        <translation>Elenco chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1051"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1051" />
         <source>Merger tous les appels</source>
         <extracomment>call_action_merge_calls</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Unisci tutte le chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="767"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1864"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="767" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1864" />
         <source>call_action_go_to_settings</source>
-        <extracomment>&quot;Paramètres&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Paramètres"</extracomment>
+        <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="771"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="771" />
         <source>conference_action_screen_sharing</source>
-        <extracomment>&quot;Partage de votre écran&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Partage de votre écran"</extracomment>
+        <translation>Condividi il tuo schermo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1207"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1207" />
         <source>conference_share_link_title</source>
         <extracomment>Partager le lien de la réunion</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Condividi il link della riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1211"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1211" />
         <source>copied</source>
         <extracomment>Copié</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Copiato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1213"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1213" />
         <source>information_popup_meeting_address_copied_to_clipboard</source>
         <extracomment>Le lien de la réunion a été copié dans le presse-papier</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Il link della riunione è stato copiato negli appunti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1222"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1226"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1232"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1222" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1226" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1232" />
         <source>conference_participants_list_title</source>
-        <extracomment>&quot;Participants (%1)&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Participants (%1)"</extracomment>
+        <translation>Partecipanti (%1)</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1253"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1261"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1253" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1261" />
         <source>group_call_participant_selected</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            %1 partecipante selezionato
+            %1 partecipanti selezionati
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1260"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1260" />
         <source>meeting_schedule_add_participants_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi partecipanti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="775"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="775" />
         <source>call_encryption_title</source>
         <extracomment>Chiffrement</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Cifratura</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="599"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="599" />
         <source>open_statistic_panel_accessible_name</source>
-        <translation type="unfinished"></translation>
+        <translation>Apri pannello statistiche</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="656"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="656" />
         <source>conference_user_is_sharing_screen</source>
-        <extracomment>&quot;You are sharing your screen&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"You are sharing your screen"</extracomment>
+        <translation>Stai condividendo il tuo schermo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="677"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="677" />
         <source>call_stop_screen_sharing</source>
-        <extracomment>&quot;Stop sharing&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Stop sharing"</extracomment>
+        <translation>Interrompi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="684"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="684" />
         <source>stop_recording_accessible_name</source>
         <extracomment>Stop recording</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Interrompi registrazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="682"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="682" />
         <source>stop_screen_sharing_accessible_name</source>
-        <extracomment>&quot;Stop screen sharing&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Stop screen sharing"</extracomment>
+        <translation>Interrompi condivisione schermo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="530"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="530" />
         <source>conference_end_to_end_encrypted</source>
         <extracomment>End to end encrypted meeting</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Riunione cifrata end-to-end</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="532"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="532" />
         <source>conference_srtp_point_to_point_encrypted</source>
         <extracomment>Point to point encrypted meeting</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Riunione cifrata punto a punto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="779"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="779" />
         <source>call_stats_title</source>
         <extracomment>Statistiques</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Statistiche</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1409"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1410"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1409" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1410" />
         <source>call_action_accept_call</source>
-        <extracomment>&quot;Accepter l&apos;appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Accepter l'appel"</extracomment>
+        <translation>Accetta la chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1429"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1430"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1429" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1430" />
         <source>call_action_end_call</source>
-        <extracomment>&quot;Terminer l&apos;appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Terminer l'appel"</extracomment>
+        <translation>Termina chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1464"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1467"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1464" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1467" />
         <source>call_action_resume_call</source>
-        <extracomment>&quot;Reprendre l&apos;appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Reprendre l'appel"</extracomment>
+        <translation>Riprendi chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1466"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1467"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1466" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1467" />
         <source>call_action_pause_call</source>
-        <extracomment>&quot;Mettre l&apos;appel en pause&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Mettre l'appel en pause"</extracomment>
+        <translation>Metti in pausa la chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1498"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1499"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1498" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1499" />
         <source>call_action_transfer_call</source>
-        <extracomment>&quot;Transférer l&apos;appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Transférer l'appel"</extracomment>
+        <translation>Trasferisci chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1521"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1522"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1521" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1522" />
         <source>call_action_start_new_call_hint</source>
-        <extracomment>&quot;Initier un nouvel appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Initier un nouvel appel"</extracomment>
+        <translation>Avvia nuova chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1544"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1545"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1544" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1545" />
         <source>call_display_call_list_hint</source>
-        <extracomment>&quot;Afficher la liste d&apos;appels&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Afficher la liste d'appels"</extracomment>
+        <translation>Visualizza elenco chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1579"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1580"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1579" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1580" />
         <source>call_deactivate_video_hint</source>
-        <extracomment>&quot;Désactiver la vidéo&quot; &quot;Activer la vidéo&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Désactiver la vidéo" "Activer la vidéo"</extracomment>
+        <translation>Disattiva video</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1579"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1580"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1579" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1580" />
         <source>call_activate_video_hint</source>
-        <translation type="unfinished"></translation>
+        <translation>Attiva video</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1596"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1599"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1596" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1599" />
         <source>call_activate_microphone</source>
-        <extracomment>&quot;Activer le micro&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Activer le micro"</extracomment>
+        <translation>Attiva microfono</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1598"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1599"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1598" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1599" />
         <source>call_deactivate_microphone</source>
-        <extracomment>&quot;Désactiver le micro&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Désactiver le micro"</extracomment>
+        <translation>Disattiva microfono</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1616"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1617"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1616" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1617" />
         <source>call_share_screen_hint</source>
-        <extracomment>Partager l&apos;écran…</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>Partager l'écran…</extracomment>
+        <translation>Condividi schermo…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1639"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1640"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1639" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1640" />
         <source>call_open_chat_hint</source>
         <extracomment>Open chat…</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Apri conversazione…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1667"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1668"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1667" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1668" />
         <source>call_rise_hand_hint</source>
-        <extracomment>&quot;Lever la main&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Lever la main"</extracomment>
+        <translation>Alza la mano</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1681"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1682"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1681" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1682" />
         <source>call_send_reaction_hint</source>
-        <extracomment>&quot;Envoyer une réaction&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Envoyer une réaction"</extracomment>
+        <translation>Invia una reazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1693"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1694"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1693" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1694" />
         <source>call_manage_participants_hint</source>
-        <extracomment>&quot;Gérer les participants&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Gérer les participants"</extracomment>
+        <translation>Gestisci partecipanti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1715"/>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1716"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1715" />
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1716" />
         <source>call_more_options_hint</source>
-        <extracomment>&quot;Plus d&apos;options…&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Plus d'options…"</extracomment>
+        <translation>Altre opzioni…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1747"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1747" />
         <source>call_action_change_conference_layout</source>
-        <extracomment>&quot;Modifier la disposition&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Modifier la disposition"</extracomment>
+        <translation>Modifica disposizione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1761"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1761" />
         <source>call_action_full_screen</source>
-        <extracomment>&quot;Mode Plein écran&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Mode Plein écran"</extracomment>
+        <translation>Modalità schermo intero</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1814"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1814" />
         <source>call_action_stop_recording</source>
-        <extracomment>&quot;Terminer l&apos;enregistrement&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Terminer l'enregistrement"</extracomment>
+        <translation>Termina registrazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1816"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1816" />
         <source>call_action_record</source>
-        <extracomment>&quot;Enregistrer l&apos;appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Enregistrer l'appel"</extracomment>
+        <translation>Registra chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1844"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1844" />
         <source>call_activate_speaker_hint</source>
-        <extracomment>&quot;Activer le son&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Activer le son"</extracomment>
+        <translation>Attiva altoparlante</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1846"/>
+        <location filename="../../view/Page/Window/Call/CallsWindow.qml" line="1846" />
         <source>call_deactivate_speaker_hint</source>
-        <extracomment>&quot;Désactiver le son&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Désactiver le son"</extracomment>
+        <translation>Disattiva altoparlante</translation>
     </message>
 </context>
 <context>
     <name>CarddavSettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="18"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="18" />
         <source>settings_contacts_carddav_title</source>
-        <extracomment>Carnet d&apos;adresse CardDAV</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>Carnet d'adresse CardDAV</extracomment>
+        <translation>Rubrica CardDAV</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="20"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="20" />
         <source>settings_contacts_carddav_subtitle</source>
-        <extracomment>&quot;Ajouter un carnet d’adresse CardDAV pour synchroniser vos contacts Linphone avec un carnet d’adresse tiers.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter un carnet d’adresse CardDAV pour synchroniser vos contacts Linphone avec un carnet d’adresse tiers."</extracomment>
+        <translation>Aggiungi una rubrica CardDAV per sincronizzare i tuoi contatti Linphone con una rubrica di terze parti.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="31"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="31" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="33"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="33" />
         <source>settings_contacts_carddav_popup_invalid_error</source>
-        <extracomment>&quot;Vérifiez que toutes les informations ont été saisies.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vérifiez que toutes les informations ont été saisies."</extracomment>
+        <translation>Verifica che tutte le informazioni siano state inserite.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="41"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="41" />
         <source>information_popup_synchronization_success_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Operazione riuscita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="43"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="43" />
         <source>settings_contacts_carddav_synchronization_success_message</source>
-        <extracomment>&quot;Le carnet d&apos;adresse CardDAV est synchronisé.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le carnet d'adresse CardDAV est synchronisé."</extracomment>
+        <translation>La rubrica CardDAV è sincronizzata.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="45"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="45" />
         <source>settings_contacts_carddav_popup_synchronization_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="47"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="47" />
         <source>settings_contacts_carddav_popup_synchronization_error_message</source>
-        <extracomment>&quot;Erreur de synchronisation : %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Erreur de synchronisation : %1"</extracomment>
+        <translation>Errore di sincronizzazione: %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="64"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="64" />
         <source>settings_contacts_delete_carddav_server_title</source>
-        <extracomment>&quot;Supprimer le carnet d&apos;adresse CardDAV ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer le carnet d'adresse CardDAV ?"</extracomment>
+        <translation>Eliminare la rubrica CardDAV?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="90"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="90" />
         <source>sip_address_display_name</source>
-        <extracomment>Nom d&apos;affichage</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>Nom d'affichage</extracomment>
+        <translation>Nome visualizzato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="99"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="99" />
         <source>settings_contacts_carddav_server_url_title</source>
-        <extracomment>&quot;URL du serveur&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"URL du serveur"</extracomment>
+        <translation>URL del server</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="107"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="107" />
         <source>username</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome utente</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="115"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="115" />
         <source>password</source>
-        <translation type="unfinished"></translation>
+        <translation>Password</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="123"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="123" />
         <source>settings_contacts_carddav_realm_title</source>
         <extracomment>Domaine d’authentification</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Dominio di autenticazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="129"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="129" />
         <source>settings_contacts_carddav_use_as_default_title</source>
-        <extracomment>&quot;Stocker ici les contacts nouvellement crées&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Stocker ici les contacts nouvellement crées"</extracomment>
+        <translation>Archivia qui i contatti appena creati</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="32"/>
+        <location filename="../../view/Page/Layout/Settings/CarddavSettingsLayout.qml" line="32" />
         <source>save</source>
         <translation>Salvare</translation>
     </message>
@@ -2083,692 +2085,692 @@
 <context>
     <name>ChangeLayoutForm</name>
     <message>
-        <location filename="../../view/Control/Form/Call/ChangeLayoutForm.qml" line="28"/>
+        <location filename="../../view/Control/Form/Call/ChangeLayoutForm.qml" line="28" />
         <source>conference_layout_grid</source>
-        <translation type="unfinished"></translation>
+        <translation>Griglia</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Call/ChangeLayoutForm.qml" line="29"/>
+        <location filename="../../view/Control/Form/Call/ChangeLayoutForm.qml" line="29" />
         <source>conference_layout_active_speaker</source>
-        <translation type="unfinished"></translation>
+        <translation>Oratore attivo</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Call/ChangeLayoutForm.qml" line="30"/>
+        <location filename="../../view/Control/Form/Call/ChangeLayoutForm.qml" line="30" />
         <source>conference_layout_audio_only</source>
-        <translation type="unfinished"></translation>
+        <translation>Solo audio</translation>
     </message>
 </context>
 <context>
     <name>ChatAudioContent</name>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatAudioContent.qml" line="36"/>
-        <location filename="../../view/Control/Display/Chat/ChatAudioContent.qml" line="78"/>
+        <location filename="../../view/Control/Display/Chat/ChatAudioContent.qml" line="36" />
+        <location filename="../../view/Control/Display/Chat/ChatAudioContent.qml" line="78" />
         <source>information_popup_error_title</source>
         <extracomment>Error</extracomment>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatAudioContent.qml" line="38"/>
+        <location filename="../../view/Control/Display/Chat/ChatAudioContent.qml" line="38" />
         <source>information_popup_voice_message_error_message</source>
         <extracomment>Failed to create voice message : error in recorder</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile creare il messaggio vocale: errore del registratore</translation>
     </message>
 </context>
 <context>
     <name>ChatCore</name>
     <message>
-        <location filename="../../core/chat/ChatCore.cpp" line="145"/>
+        <location filename="../../core/chat/ChatCore.cpp" line="145" />
         <source>info_toast_deleted_title</source>
         <extracomment>Deleted</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Eliminato</translation>
     </message>
     <message>
-        <location filename="../../core/chat/ChatCore.cpp" line="147"/>
+        <location filename="../../core/chat/ChatCore.cpp" line="147" />
         <source>info_toast_deleted_message_history</source>
         <extracomment>Message history has been deleted</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>La cronologia dei messaggi è stata eliminata</translation>
     </message>
 </context>
 <context>
     <name>ChatDroppableTextArea</name>
     <message>
-        <location filename="../../view/Control/Input/Chat/ChatDroppableTextArea.qml" line="175"/>
+        <location filename="../../view/Control/Input/Chat/ChatDroppableTextArea.qml" line="175" />
         <source>chat_view_send_area_placeholder_text</source>
         <extracomment>Say something… : placeholder text for sending message text area</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Scrivi qualcosa…</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Input/Chat/ChatDroppableTextArea.qml" line="214"/>
+        <location filename="../../view/Control/Input/Chat/ChatDroppableTextArea.qml" line="214" />
         <source>cannot_record_while_in_call_tooltip</source>
         <extracomment>Cannot record a message while a call is ongoing</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile registrare un messaggio durante una chiamata in corso</translation>
     </message>
 </context>
 <context>
     <name>ChatListView</name>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="273"/>
+        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="273" />
         <source>chat_message_is_writing_info</source>
         <extracomment>%1 is writing…</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>%1 sta scrivendo…</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="275"/>
+        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="275" />
         <source>chat_message_draft_sending_text</source>
-        <translation type="unfinished"></translation>
+        <translation>Bozza: %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="421"/>
+        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="421" />
         <source>chat_room_delete</source>
-        <extracomment>&quot;Delete&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Delete"</extracomment>
+        <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="360"/>
+        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="360" />
         <source>chat_room_mute</source>
-        <translation type="unfinished"></translation>
+        <translation>Silenzia</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="359"/>
+        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="359" />
         <source>chat_room_unmute</source>
-        <extracomment>&quot;Mute&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Mute"</extracomment>
+        <translation>Riattiva audio</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="373"/>
+        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="373" />
         <source>chat_room_mark_as_read</source>
-        <extracomment>&quot;Mark as read&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Mark as read"</extracomment>
+        <translation>Segna come letto</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="392"/>
+        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="392" />
         <source>chat_room_leave</source>
-        <extracomment>&quot;leave&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"leave"</extracomment>
+        <translation>Abbandona</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="398"/>
+        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="398" />
         <source>chat_list_leave_chat_popup_title</source>
         <extracomment>leave the conversation ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Abbandonare la conversazione?</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="400"/>
+        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="400" />
         <source>chat_list_leave_chat_popup_message</source>
         <extracomment>You will not be able to send or receive messages in this conversation anymore. Do You want to continue ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Non potrai più inviare o ricevere messaggi in questa conversazione. Vuoi continuare?</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="427"/>
+        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="427" />
         <source>chat_list_delete_chat_popup_title</source>
         <extracomment>Delete the conversation ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Eliminare la conversazione?</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="429"/>
+        <location filename="../../view/Control/Display/Chat/ChatListView.qml" line="429" />
         <source>chat_list_delete_chat_popup_message</source>
         <extracomment>This conversation and all its messages will be deleted. Do You want to continue ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Questa conversazione e tutti i suoi messaggi verranno eliminati. Vuoi continuare?</translation>
     </message>
 </context>
 <context>
     <name>ChatMessage</name>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="490"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="490" />
         <source>chat_message_copy_selection</source>
-        <extracomment>&quot;Copy selection&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Copy selection"</extracomment>
+        <translation>Copia selezione</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="492"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="492" />
         <source>chat_message_copy</source>
-        <extracomment>&quot;Copy&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Copy"</extracomment>
+        <translation>Copia</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="500"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="500" />
         <source>chat_message_copied_to_clipboard_title</source>
         <extracomment>Copied</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Copiato</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="502"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="502" />
         <source>chat_message_copied_to_clipboard_toast</source>
-        <extracomment>&quot;to clipboard&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"to clipboard"</extracomment>
+        <translation>negli appunti</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="132"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="132" />
         <source>chat_message_remote_replied</source>
         <extracomment>%1 replied</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>%1 ha risposto</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="99"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="99" />
         <source>chat_message_forwarded</source>
         <extracomment>Forwarded</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Inoltrato</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="130"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="130" />
         <source>chat_message_remote_replied_to</source>
         <extracomment>%1 replied to %2</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>%1 ha risposto a %2</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="135"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="135" />
         <source>chat_message_user_replied_to</source>
         <extracomment>You replied to %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Hai risposto a %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="137"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="137" />
         <source>chat_message_user_replied</source>
         <extracomment>You replied</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Hai risposto</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="439"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="439" />
         <source>chat_message_send_again</source>
-        <extracomment>&quot;Re-send&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Re-send"</extracomment>
+        <translation>Reinvia</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="450"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="450" />
         <source>chat_message_reception_info</source>
-        <extracomment>&quot;Reception info&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Reception info"</extracomment>
+        <translation>Informazioni sulla ricezione</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="462"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="462" />
         <source>menu_edit_chat_message</source>
-        <extracomment>&quot;Edit&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Edit"</extracomment>
+        <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="476"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="476" />
         <source>chat_message_reply</source>
         <extracomment>Reply</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Rispondi</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="510"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="510" />
         <source>chat_message_forward</source>
         <extracomment>Forward</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Inoltra</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="527"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="527" />
         <source>chat_message_delete</source>
-        <extracomment>&quot;Delete&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Delete"</extracomment>
+        <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="316"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessage.qml" line="316" />
         <source>conversation_message_edited_label</source>
-        <translation type="unfinished"></translation>
+        <translation>Modificato</translation>
     </message>
 </context>
 <context>
     <name>ChatMessageContentCore</name>
     <message>
-        <location filename="../../core/chat/message/content/ChatMessageContentCore.cpp" line="111"/>
+        <location filename="../../core/chat/message/content/ChatMessageContentCore.cpp" line="111" />
         <source>download_file_default_error</source>
         <extracomment>Error downloading file %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Errore durante il download del file %1</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/content/ChatMessageContentCore.cpp" line="112"/>
+        <location filename="../../core/chat/message/content/ChatMessageContentCore.cpp" line="112" />
         <source>info_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/content/ChatMessageContentCore.cpp" line="144"/>
+        <location filename="../../core/chat/message/content/ChatMessageContentCore.cpp" line="144" />
         <source>popup_error_title</source>
         <extracomment>Error</extracomment>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/content/ChatMessageContentCore.cpp" line="146"/>
+        <location filename="../../core/chat/message/content/ChatMessageContentCore.cpp" line="146" />
         <source>popup_open_file_error_does_not_exist_message</source>
         <extracomment>Could not open file : unknown path %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile aprire il file: percorso sconosciuto %1</translation>
     </message>
 </context>
 <context>
     <name>ChatMessageContentList</name>
     <message>
-        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="119"/>
-        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="128"/>
-        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="165"/>
-        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="171"/>
+        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="119" />
+        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="128" />
+        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="165" />
+        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="171" />
         <source>popup_error_title</source>
         <extracomment>Error adding file
 ----------
 Error</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Errore durante l'aggiunta del file</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="121"/>
+        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="121" />
         <source>popup_error_path_does_not_exist_message</source>
         <extracomment>File was not found: %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>File non trovato: %1</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="123"/>
+        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="123" />
         <source>popup_error_nb_files_not_found_message</source>
         <extracomment>%n files were not found</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>%1 file non trovati</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="130"/>
+        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="130" />
         <source>popup_error_max_files_count_message</source>
         <extracomment>You can send 12 files maximum at a time. %n files were ignored</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>Puoi inviare al massimo 12 file alla volta. %n file sono stati ignorati<numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="167"/>
+        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="167" />
         <source>popup_error_file_too_big_message</source>
         <extracomment>%n files were ignored cause they exceed the maximum size. (Size limit=%2)</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>%n file sono stati ignorati perché superano la dimensione massima consentita (limite: %2)</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="176"/>
+        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="176" />
         <source>popup_error_unsupported_files_message</source>
         <extracomment>Unable to get supported mime type for %1 files.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile determinare il tipo MIME supportato per %1 file</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="174"/>
+        <location filename="../../core/chat/message/content/ChatMessageContentList.cpp" line="174" />
         <source>popup_error_unsupported_file_message</source>
         <extracomment>Unable to get supported mime type for: `%1`.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile determinare il tipo MIME supportato per: `%1`</translation>
     </message>
 </context>
 <context>
     <name>ChatMessageContentModel</name>
     <message>
-        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="87"/>
+        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="87" />
         <source>download_error_object_doesnt_exist</source>
         <extracomment>Internal error : message object associated to this content does not exist anymore !</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Errore interno: l'oggetto messaggio associato a questo contenuto non esiste più!</translation>
     </message>
     <message>
-        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="102"/>
+        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="102" />
         <source>download_file_server_error</source>
         <extracomment>Error while trying to download content : %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Errore durante il tentativo di scaricare il contenuto: %1</translation>
     </message>
     <message>
-        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="112"/>
+        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="112" />
         <source>download_file_error_no_safe_file_path</source>
         <extracomment>Unable to create safe file path for: %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile creare un percorso file sicuro per: %1</translation>
     </message>
     <message>
-        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="121"/>
+        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="121" />
         <source>download_file_error_file_transfer_unavailable</source>
         <extracomment>This file was already downloaded and is no more on the server. Your peer have to resend it if you want to get it</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Questo file è già stato scaricato e non è più disponibile sul server. Il tuo interlocutore deve rinviarlo se vuoi riceverlo</translation>
     </message>
     <message>
-        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="126"/>
+        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="126" />
         <source>download_file_error_null_name</source>
-        <extracomment>Content name is null, can&apos;t download it !</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>Content name is null, can't download it !</extracomment>
+        <translation>Il nome del contenuto è nullo, impossibile scaricarlo!</translation>
     </message>
     <message>
-        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="134"/>
+        <location filename="../../model/chat/message/content/ChatMessageContentModel.cpp" line="134" />
         <source>download_file_error_unable_to_download</source>
         <extracomment>Unable to download file of entry %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile scaricare il file della voce %1</translation>
     </message>
 </context>
 <context>
     <name>ChatMessageCore</name>
     <message>
-        <location filename="../../core/chat/message/ChatMessageCore.cpp" line="163"/>
+        <location filename="../../core/chat/message/ChatMessageCore.cpp" line="163" />
         <source>all_reactions_label</source>
-        <extracomment>&quot;Reactions&quot;: all reactions for one message label</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Reactions": all reactions for one message label</extracomment>
+        <translation>Reazioni</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/ChatMessageCore.cpp" line="224"/>
+        <location filename="../../core/chat/message/ChatMessageCore.cpp" line="224" />
         <source>info_toast_deleted_title</source>
         <extracomment>Deleted</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Eliminato</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/ChatMessageCore.cpp" line="226"/>
+        <location filename="../../core/chat/message/ChatMessageCore.cpp" line="226" />
         <source>info_toast_deleted_message</source>
         <extracomment>The message has been deleted</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Il messaggio è stato eliminato</translation>
     </message>
 </context>
 <context>
     <name>ChatMessageInvitationBubble</name>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="40"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="40" />
         <source>ics_bubble_meeting_from</source>
-        <translation type="unfinished"></translation>
+        <translation>da </translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="41"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="41" />
         <source>ics_bubble_meeting_to</source>
-        <translation type="unfinished"></translation>
+        <translation> a </translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="63"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="63" />
         <source>ics_bubble_meeting_modified</source>
         <extracomment>Meeting has been updated</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>La riunione è stata aggiornata</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="66"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="66" />
         <source>ics_bubble_meeting_cancelled</source>
         <extracomment>Meeting has been canceled</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>La riunione è stata annullata</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="182"/>
-        <source></source>
-        <translation type="unfinished"></translation>
+        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="182" />
+        <source />
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="245"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="245" />
         <source>ics_bubble_description_title</source>
         <extracomment>Description</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="297"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="297" />
         <source>ics_bubble_join</source>
-        <extracomment>&quot;Rejoindre&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Rejoindre"</extracomment>
+        <translation>Partecipa</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="287"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessageInvitationBubble.qml" line="287" />
         <source>ics_bubble_participants</source>
         <extracomment>%n participant(s)</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>%1 partecipanti<numerusform />
+            <numerusform />
         </translation>
     </message>
 </context>
 <context>
     <name>ChatMessagesListView</name>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="131"/>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="142"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="131" />
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="142" />
         <source>popup_info_find_message_title</source>
         <extracomment>Find message</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Trova messaggio</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="144"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="144" />
         <source>info_popup_no_result_message</source>
         <extracomment>No result found</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nessun risultato trovato</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="136"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="136" />
         <source>info_popup_first_result_message</source>
         <extracomment>First result reached</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Raggiunto il primo risultato</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="134"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="134" />
         <source>info_popup_last_result_message</source>
         <extracomment>Last result reached</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Raggiunto l'ultimo risultato</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="192"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="192" />
         <source>chat_message_list_encrypted_header_title</source>
         <extracomment>End to end encrypted chat</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chat crittografata end-to-end</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="194"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="194" />
         <source>unencrypted_conversation_warning</source>
         <extracomment>This conversation is not encrypted !</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Questa conversazione non è crittografata!</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="205"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="205" />
         <source>chat_message_list_encrypted_header_message</source>
         <extracomment>Messages in this conversation are e2e encrypted. 
  Only your correspondent can decrypt them.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>I messaggi in questa conversazione sono crittografati end-to-end.
+Solo il tuo interlocutore può decifrarli.</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="207"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="207" />
         <source>chat_message_list_not_encrypted_header_message</source>
         <extracomment>Messages are not end to end encrypted, 
- may sure you don&apos;t share any sensitive information !</extracomment>
-        <translation type="unfinished"></translation>
+ may sure you don't share any sensitive information !</extracomment>
+        <translation>I messaggi non sono crittografati end-to-end,
+assicurati di non condividere informazioni sensibili!</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="247"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="247" />
         <source>chat_message_is_writing_info</source>
         <extracomment>%1 is writing…</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>%1 sta scrivendo…</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="268"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="268" />
         <source>conversation_dialog_delete_chat_message_title</source>
-        <extracomment>&quot;Supprimer le message ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer le message ?"</extracomment>
+        <translation>Eliminare questo messaggio?</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="276"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="276" />
         <source>conversation_dialog_delete_locally_label</source>
-        <translation type="unfinished"></translation>
+        <translation>Solo per me</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="287"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="287" />
         <source>conversation_dialog_delete_for_everyone_label</source>
-        <translation type="unfinished"></translation>
+        <translation>Per tutti</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="298"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="298" />
         <source>dialog_cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="380"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="380" />
         <source>info_toast_deleted_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminato</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="382"/>
+        <location filename="../../view/Control/Display/Chat/ChatMessagesListView.qml" line="382" />
         <source>info_toast_deleted_message</source>
         <extracomment>The message has been deleted</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Il messaggio è stato eliminato</translation>
     </message>
 </context>
 <context>
     <name>ChatPage</name>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="14"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="14" />
         <source>chat_start_title</source>
-        <extracomment>&quot;Nouvelle conversation&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nouvelle conversation"</extracomment>
+        <translation>Nuova conversazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="16"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="16" />
         <source>chat_empty_title</source>
-        <extracomment>&quot;Aucune conversation&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucune conversation"</extracomment>
+        <translation>Nessuna conversazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="52"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="52" />
         <source>info_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="54"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="54" />
         <source>info_popup_chatroom_creation_failed</source>
         <extracomment>Chat room creation failed !</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Creazione della chat non riuscita!</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="48"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="48" />
         <source>loading_popup_chatroom_creation_pending_message</source>
         <extracomment>Chat room is being created...</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Creazione della chat in corso...</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="103"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="103" />
         <source>chat_dialog_delete_chat_title</source>
         <extracomment>Supprimer la conversation ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Eliminare la conversazione?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="105"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="105" />
         <source>chat_dialog_delete_chat_message</source>
-        <extracomment>&quot;La conversation et tous ses messages seront supprimés.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"La conversation et tous ses messages seront supprimés."</extracomment>
+        <translation>Questa conversazione e tutti i suoi messaggi verranno eliminati.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="139"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="139" />
         <source>chat_list_title</source>
-        <extracomment>&quot;Conversations&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Conversations"</extracomment>
+        <translation>Conversazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="158"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="158" />
         <source>menu_mark_all_as_read</source>
-        <extracomment>&quot;mark all as read&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"mark all as read"</extracomment>
+        <translation>Segna tutto come letto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="189"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="189" />
         <source>chat_search_in_history</source>
-        <extracomment>&quot;Rechercher une conversation&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Rechercher une conversation"</extracomment>
+        <translation>Cerca una chat</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="212"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="212" />
         <source>list_filter_no_result_found</source>
-        <extracomment>&quot;Aucun résultat…&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucun résultat…"</extracomment>
+        <translation>Nessun risultato…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="214"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="214" />
         <source>chat_list_empty_history</source>
-        <extracomment>&quot;Aucune conversation dans votre historique&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucune conversation dans votre historique"</extracomment>
+        <translation>Nessuna conversazione nella cronologia</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="292"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="292" />
         <source>chat_action_start_new_chat</source>
-        <extracomment>&quot;New chat&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"New chat"</extracomment>
+        <translation>Nuova conversazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="330"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="330" />
         <source>chat_start_group_chat_title</source>
-        <extracomment>&quot;Nouveau groupe&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nouveau groupe"</extracomment>
+        <translation>Nuovo gruppo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="332"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="332" />
         <source>chat_action_start_group_chat</source>
-        <extracomment>&quot;Créer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Créer"</extracomment>
+        <translation>Crea</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="348"/>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="371"/>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="376"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="348" />
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="371" />
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="376" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="350"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="350" />
         <source>information_popup_chat_creation_failed_message</source>
-        <extracomment>&quot;La création a échoué&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"La création a échoué"</extracomment>
+        <translation>Creazione non riuscita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="368"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="368" />
         <source>group_chat_error_must_have_name</source>
-        <extracomment>&quot;Un nom doit être donné au groupe</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Un nom doit être donné au groupe</extracomment>
+        <translation>È necessario assegnare un nome al gruppo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="373"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="373" />
         <source>group_chat_error_no_participant</source>
-        <extracomment>&quot;Please select at least one participant</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Please select at least one participant</extracomment>
+        <translation>Seleziona almeno un partecipante</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="378"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="378" />
         <source>group_call_error_not_connected</source>
-        <extracomment>&quot;Vous n&apos;etes pas connecté&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vous n'etes pas connecté"</extracomment>
+        <translation>Non sei connesso</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="384"/>
+        <location filename="../../view/Page/Main/Chat/ChatPage.qml" line="384" />
         <source>chat_creation_in_progress</source>
         <extracomment>Creation de la conversation en cours …</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Creazione della conversazione in corso…</translation>
     </message>
 </context>
 <context>
     <name>ChatSettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="16"/>
+        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="16" />
         <source>settings_chat_attached_files_title</source>
         <extracomment>Attached files</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>File allegati</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="23"/>
+        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="23" />
         <source>settings_chat_notifications_title</source>
         <extracomment>Notifications</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Notifiche</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="48"/>
+        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="48" />
         <source>settings_chat_attached_files_auto_download_title</source>
-        <extracomment>&quot;Automatic download&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Automatic download"</extracomment>
+        <translation>Download automatico</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="50"/>
+        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="50" />
         <source>settings_chat_attached_files_auto_download_subtitle</source>
-        <extracomment>&quot;Automatically download transferred or received files in conversations&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Automatically download transferred or received files in conversations"</extracomment>
+        <translation>Scarica automaticamente i file trasferiti o ricevuti nelle conversazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="57"/>
+        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="57" />
         <source>settings_chat_download_folder_title</source>
-        <extracomment>&quot;Dossier de téléchargement des fichiers&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Dossier de téléchargement des fichiers"</extracomment>
+        <translation>Cartella di download dei file</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="64"/>
+        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="64" />
         <source>settings_chat_download_folder_browse_button</source>
         <extracomment>Browse folders</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Sfoglia cartelle</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="80"/>
+        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="80" />
         <source>settings_chat_display_notification_content_title</source>
-        <extracomment>&quot;Display content&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Display content"</extracomment>
+        <translation>Mostra contenuto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="82"/>
+        <location filename="../../view/Page/Layout/Settings/ChatSettingsLayout.qml" line="82" />
         <source>settings_chat_display_notification_content_subtitle</source>
-        <extracomment>&quot;Display the content of the received message&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Display the content of the received message"</extracomment>
+        <translation>Mostra il contenuto del messaggio ricevuto</translation>
     </message>
 </context>
 <context>
@@ -2801,862 +2803,892 @@ Error</extracomment>
 <context>
     <name>ComboBox</name>
     <message>
-        <location filename="../../view/Control/Button/ComboBox.qml" line="48"/>
+        <location filename="../../view/Control/Button/ComboBox.qml" line="48" />
         <source>combobox_with_value_accessible_name</source>
         <extracomment>%1 actual value %2</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>%1 valore attuale %2</translation>
     </message>
 </context>
 <context>
     <name>ConferenceInfoCore</name>
     <message>
-        <location filename="../../core/conference/ConferenceInfoCore.cpp" line="587"/>
+        <location filename="../../core/conference/ConferenceInfoCore.cpp" line="587" />
         <source>information_popup_error_title</source>
-        <extracomment>&quot;Erreur&quot;</extracomment>
+        <extracomment>"Erreur"</extracomment>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../core/conference/ConferenceInfoCore.cpp" line="589"/>
+        <location filename="../../core/conference/ConferenceInfoCore.cpp" line="589" />
         <source>information_popup_disconnected_account_message</source>
-        <extracomment>&quot;Votre compte est déconnecté&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Votre compte est déconnecté"</extracomment>
+        <translation>Il tuo account è disconnesso</translation>
     </message>
 </context>
 <context>
     <name>Contact</name>
     <message>
-        <location filename="../../view/Control/Display/Contact/Contact.qml" line="165"/>
+        <location filename="../../view/Control/Display/Contact/Contact.qml" line="165" />
         <source>information_popup_error_title</source>
         <extracomment>Erreur</extracomment>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/Contact.qml" line="167"/>
+        <location filename="../../view/Control/Display/Contact/Contact.qml" line="167" />
         <source>information_popup_voicemail_address_undefined_message</source>
-        <extracomment>L&apos;URI de messagerie vocale n&apos;est pas définie.</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>L'URI de messagerie vocale n'est pas définie.</extracomment>
+        <translation>L'URI della segreteria telefonica non è definito.</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/Contact.qml" line="181"/>
+        <location filename="../../view/Control/Display/Contact/Contact.qml" line="181" />
         <source>account_settings_name_accessible_name</source>
         <extracomment>Account settings of %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impostazioni account di %1</translation>
     </message>
 </context>
 <context>
     <name>ContactEdition</name>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="27"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="27" />
         <source>contact_editor_title</source>
-        <extracomment>&quot;Modifier contact&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Modifier contact"</extracomment>
+        <translation>Modifica contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="29"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="29" />
         <source>save</source>
-        <extracomment>&quot;Enregistrer</extracomment>
+        <extracomment>"Enregistrer</extracomment>
         <translation>Salvare</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="43"/>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="66"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="43" />
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="66" />
         <source>contact_editor_dialog_cancel_change_message</source>
-        <extracomment>&quot;Les changements seront annulés. Souhaitez-vous continuer ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Les changements seront annulés. Souhaitez-vous continuer ?"</extracomment>
+        <translation>Le modifiche verranno annullate. Vuoi continuare?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="63"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="63" />
         <source>close_accessible_name</source>
         <extracomment>Close %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiudi %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="94"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="94" />
         <source>contact_editor_mandatory_first_name_or_company_not_filled</source>
-        <extracomment>&quot;Veuillez saisir un prénom ou un nom d&apos;entreprise&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Veuillez saisir un prénom ou un nom d'entreprise"</extracomment>
+        <translation>Inserisci un nome o una ragione sociale</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="98"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="98" />
         <source>contact_editor_mandatory_address_or_number_not_filled</source>
-        <extracomment>&quot;Veuillez saisir une adresse ou un numéro de téléphone&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Veuillez saisir une adresse ou un numéro de téléphone"</extracomment>
+        <translation>Inserisci un indirizzo SIP o un numero di telefono</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="115"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="115" />
         <source>contact_editor_add_image_label</source>
-        <extracomment>&quot;Ajouter une image&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter une image"</extracomment>
+        <translation>Aggiungi un'immagine</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="133"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="133" />
         <source>contact_details_edit</source>
-        <extracomment>&quot;Modifier&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Modifier"</extracomment>
+        <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="142"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="142" />
         <source>edit_contact_image_accessible_name</source>
-        <extracomment>&quot;Edit contact image&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Edit contact image"</extracomment>
+        <translation>Modifica immagine contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="160"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="160" />
         <source>contact_details_delete</source>
-        <extracomment>&quot;Supprimer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer"</extracomment>
+        <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="169"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="169" />
         <source>delete_contact_image_accessible_name</source>
-        <extracomment>&quot;Delete contact image&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Delete contact image"</extracomment>
+        <translation>Elimina immagine contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="222"/>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="235"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="222" />
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="235" />
         <source>contact_editor_first_name</source>
-        <extracomment>&quot;Prénom&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Prénom"</extracomment>
+        <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="240"/>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="250"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="240" />
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="250" />
         <source>contact_editor_last_name</source>
-        <extracomment>&quot;Nom&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nom"</extracomment>
+        <translation>Cognome</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="255"/>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="265"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="255" />
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="265" />
         <source>contact_editor_company</source>
-        <extracomment>&quot;Entreprise&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Entreprise"</extracomment>
+        <translation>Azienda</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="270"/>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="285"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="270" />
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="285" />
         <source>contact_editor_job_title</source>
-        <extracomment>&quot;Fonction&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Fonction"</extracomment>
+        <translation>Ruolo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="318"/>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="350"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="318" />
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="350" />
         <source>sip_address</source>
-        <translation type="unfinished"></translation>
+        <translation>Indirizzo SIP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="328"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="328" />
         <source>sip_address_number_accessible_name</source>
-        <extracomment>&quot;SIP address number %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"SIP address number %1"</extracomment>
+        <translation>Numero indirizzo SIP %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="343"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="343" />
         <source>remove_sip_address_accessible_name</source>
-        <extracomment>&quot;Remove SIP address %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Remove SIP address %1"</extracomment>
+        <translation>Rimuovi indirizzo SIP %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="374"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="374" />
         <source>new_sip_address_accessible_name</source>
-        <extracomment>&quot;New SIP address&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"New SIP address"</extracomment>
+        <translation>Nuovo indirizzo SIP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="411"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="411" />
         <source>phone_number_number_accessible_name</source>
-        <extracomment>&quot;Phone number number %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Phone number number %1"</extracomment>
+        <translation>Numero di telefono numero %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="426"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="426" />
         <source>remove_phone_number_accessible_name</source>
         <extracomment>Remove phone number %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Rimuovi numero di telefono %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="457"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="457" />
         <source>new_phone_number_accessible_name</source>
-        <extracomment>&quot;New phone number&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"New phone number"</extracomment>
+        <translation>Nuovo numero di telefono</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="408"/>
-        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="434"/>
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="408" />
+        <location filename="../../view/Page/Form/Contact/ContactEdition.qml" line="434" />
         <source>phone</source>
-        <extracomment>&quot;Téléphone&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Téléphone"</extracomment>
+        <translation>Telefono</translation>
     </message>
 </context>
 <context>
     <name>ContactListItem</name>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="155"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="155" />
         <source>call_with_contact_name_accessible_button</source>
-        <extracomment>&quot;Call %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Call %1"</extracomment>
+        <translation>Chiama %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="173"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="173" />
         <source>video_call_with_contact_name_accessible_button</source>
-        <extracomment>&quot;Video call %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Video call %1"</extracomment>
+        <translation>Videochiama %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="196"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="196" />
         <source>message_with_contact_name_accessible_button</source>
-        <extracomment>&quot;Message %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Message %1"</extracomment>
+        <translation>Messaggio a %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="214"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="214" />
         <source>contact_details_remove_from_favourites</source>
-        <extracomment>&quot;Enlever des favoris&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Enlever des favoris"</extracomment>
+        <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="216"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="216" />
         <source>contact_details_add_to_favourites</source>
-        <extracomment>&quot;Ajouter aux favoris&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter aux favoris"</extracomment>
+        <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="230"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="230" />
         <source>Partager</source>
-        <translation type="unfinished"></translation>
+        <translation>Condividi</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="243"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="243" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="245"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="245" />
         <source>information_popup_vcard_creation_error</source>
         <extracomment>La création du fichier vcard a échoué</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Creazione della vCard non riuscita</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="249"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="249" />
         <source>information_popup_vcard_creation_title</source>
         <extracomment>VCard créée</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>VCard creata</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="251"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="251" />
         <source>information_popup_vcard_creation_success</source>
-        <extracomment>&quot;VCard du contact enregistrée dans %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"VCard du contact enregistrée dans %1"</extracomment>
+        <translation>La vCard del contatto è stata salvata in %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="253"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="253" />
         <source>contact_sharing_email_title</source>
         <extracomment>Partage de contact</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Condividi contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="259"/>
+        <location filename="../../view/Control/Display/Contact/ContactListItem.qml" line="259" />
         <source>contact_details_delete</source>
-        <extracomment>&quot;Supprimer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer"</extracomment>
+        <translation>Elimina</translation>
     </message>
 </context>
 <context>
     <name>ContactListView</name>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListView.qml" line="193"/>
+        <location filename="../../view/Control/Display/Contact/ContactListView.qml" line="193" />
         <source>shrink_accessible_name</source>
         <extracomment>Shrink %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Riduci %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/ContactListView.qml" line="195"/>
+        <location filename="../../view/Control/Display/Contact/ContactListView.qml" line="195" />
         <source>expand_accessible_name</source>
         <extracomment>Expand %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Espandi %1</translation>
     </message>
 </context>
 <context>
     <name>ContactPage</name>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="15"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="268" />
+        <source>import_contacts_accessible_name</source>
+        <extracomment>Import contacts from a vCard file</extracomment>
+        <translation>Importa contatti</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="285" />
+        <source>import_contacts_from_pbx_accessible_name</source>
+        <extracomment>Import contacts from the PBX extension list</extracomment>
+        <translation>Importa contatti dal PBX</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="304" />
+        <source>information_popup_success_title</source>
+        <translation>Operazione riuscita</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="305" />
+        <source>information_popup_vcard_import_success_message</source>
+        <extracomment>"Contacts importés"</extracomment>
+        <translation>%1 contatti importati</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="310" />
+        <source>information_popup_vcard_import_error_message</source>
+        <extracomment>"Aucun contact n'a pu être importé depuis ce fichier."</extracomment>
+        <translation>Non è stato possibile importare alcun contatto da questo file.</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="15" />
         <source>contacts_add</source>
-        <extracomment>&quot;Ajouter un contact&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter un contact"</extracomment>
+        <translation>Aggiungi un contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="17"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="17" />
         <source>contacts_list_empty</source>
-        <extracomment>&quot;Aucun contact pour le moment&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucun contact pour le moment"</extracomment>
+        <translation>Nessun contatto al momento</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="92"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="92" />
         <source>contact_new_title</source>
-        <extracomment>&quot;Nouveau contact&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nouveau contact"</extracomment>
+        <translation>Nuovo contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="94"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="94" />
         <source>create</source>
-        <translation type="unfinished"></translation>
+        <translation>Crea</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="102"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="102" />
         <source>contact_edit_title</source>
-        <extracomment>&quot;Modifier contact&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Modifier contact"</extracomment>
+        <translation>Modifica contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="103"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="103" />
         <source>save</source>
         <translation>Salvare</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="117"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="117" />
         <source>contact_dialog_delete_title</source>
-        <extracomment>Supprimer %1 ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>Supprimer %1 ?"</extracomment>
+        <translation>Eliminare %1?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="119"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="119" />
         <source>contact_dialog_delete_message</source>
         <extracomment>Ce contact sera définitivement supprimé.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Questo contatto verrà eliminato definitivamente.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="126"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="126" />
         <source>contact_deleted_toast</source>
-        <extracomment>&quot;Contact supprimé&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Contact supprimé"</extracomment>
+        <translation>Contatto eliminato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="128"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="128" />
         <source>contact_deleted_message</source>
-        <extracomment>&quot;%1 a été supprimé&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"%1 a été supprimé"</extracomment>
+        <translation>%1 è stato eliminato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="144"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="144" />
         <source>contact_dialog_devices_trust_popup_title</source>
-        <extracomment>&quot;Augmenter la confiance&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Augmenter la confiance"</extracomment>
+        <translation>Aumenta il livello di fiducia</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="146"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="146" />
         <source>contact_dialog_devices_trust_popup_message</source>
-        <extracomment>&quot;Pour augmenter le niveau de confiance vous devez appeler les différents appareils de votre contact et valider un code.&lt;br&gt;&lt;br&gt;Vous êtes sur le point d’appeler “%1” voulez vous continuer ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Pour augmenter le niveau de confiance vous devez appeler les différents appareils de votre contact et valider un code.&lt;br&gt;&lt;br&gt;Vous êtes sur le point d’appeler “%1” voulez vous continuer ?"</extracomment>
+        <translation>Per aumentare il livello di fiducia devi chiamare i dispositivi del tuo contatto e convalidare un codice.
+Stai per chiamare "%1", vuoi continuare?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="155"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="155" />
         <source>popup_do_not_show_again</source>
         <extracomment>Ne plus afficher</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Non mostrare più</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="170"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="170" />
         <source>cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="176"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="176" />
         <source>dialog_call</source>
-        <extracomment>&quot;Appeler&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appeler"</extracomment>
+        <translation>Chiama</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="193"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="193" />
         <source>contact_dialog_devices_trust_help_title</source>
-        <extracomment>&quot;Niveau de confiance&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Niveau de confiance"</extracomment>
+        <translation>Livello di fiducia</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="195"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="195" />
         <source>contact_dialog_devices_trust_help_message</source>
-        <extracomment>&quot;Vérifiez les appareils de votre contact pour confirmer que vos communications seront sécurisées et sans compromission. &lt;br&gt;Quand tous seront vérifiés, vous atteindrez le niveau de confiance maximal.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vérifiez les appareils de votre contact pour confirmer que vos communications seront sécurisées et sans compromission. &lt;br&gt;Quand tous seront vérifiés, vous atteindrez le niveau de confiance maximal."</extracomment>
+        <translation>Verifica i dispositivi del tuo contatto per confermare che le comunicazioni saranno sicure e non compromesse. Quando tutti saranno verificati, raggiungerai il livello di fiducia massimo.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="218"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="218" />
         <source>dialog_ok</source>
-        <extracomment>&quot;Ok&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ok"</extracomment>
+        <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="247"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="247" />
         <source>bottom_navigation_contacts_label</source>
-        <extracomment>&quot;Contacts&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Contacts"</extracomment>
+        <translation>Contatti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="288"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="288" />
         <source>search_bar_look_for_contact_text</source>
         <extracomment>Rechercher un contact</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Cerca un contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="300"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="300" />
         <source>list_filter_no_result_found</source>
         <extracomment>Aucun résultat…</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nessun risultato…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="302"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="302" />
         <source>contact_list_empty</source>
         <extracomment>Aucun contact pour le moment</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nessun contatto al momento</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="385"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="385" />
         <source>expand_accessible_name</source>
         <extracomment>Expand %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Espandi %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="625"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="625" />
         <source>contact_details_medias_and_documents_title</source>
-        <extracomment>&quot;Medias &amp; documents&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Medias &amp; documents"</extracomment>
+        <translation>Media e documenti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="383"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="383" />
         <source>shrink_accessible_name</source>
         <extracomment>Shrink %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Riduci %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="269"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="269" />
         <source>create_contact_accessible_name</source>
         <extracomment>Create new contact</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Crea nuovo contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="369"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="369" />
         <source>more_info_accessible_name</source>
         <extracomment>More info %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Maggiori informazioni %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="405"/>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="807"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="405" />
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="807" />
         <source>contact_details_edit</source>
         <extracomment>Edit
 ----------
-&quot;Éditer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+"Éditer"</extracomment>
+        <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="419"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="419" />
         <source>contact_call_action</source>
-        <extracomment>&quot;Appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel"</extracomment>
+        <translation>Chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="430"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="430" />
         <source>contact_message_action</source>
-        <extracomment>&quot;Message&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Message"</extracomment>
+        <translation>Messaggio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="444"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="444" />
         <source>contact_video_call_action</source>
-        <extracomment>&quot;Appel vidéo&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel vidéo"</extracomment>
+        <translation>Videochiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="493"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="493" />
         <source>contact_details_numbers_and_addresses_title</source>
-        <extracomment>&quot;Coordonnées&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Coordonnées"</extracomment>
+        <translation>Dettagli contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="549"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="549" />
         <source>call_adress_accessible_name</source>
         <extracomment>Call address %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiama indirizzo %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="582"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="582" />
         <source>contact_details_company_name</source>
-        <extracomment>&quot;Société :&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Société :"</extracomment>
+        <translation>Azienda:</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="603"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="603" />
         <source>contact_details_job_title</source>
-        <extracomment>&quot;Poste :&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Poste :"</extracomment>
+        <translation>Ruolo:</translation>
     </message>
     <message>
         <source>contact_details_medias_title</source>
-        <extracomment>&quot;Medias&quot;</extracomment>
+        <extracomment>"Medias"</extracomment>
         <translation type="vanished">Medias</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="641"/>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="661"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="641" />
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="661" />
         <source>contact_details_medias_subtitle</source>
-        <extracomment>&quot;Show shared medias&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Show shared medias"</extracomment>
+        <translation>Mostra media condivisi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="680"/>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="700"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="680" />
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="700" />
         <source>contact_details_documents_subtitle</source>
-        <extracomment>&quot;Show shared documents&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Show shared documents"</extracomment>
+        <translation>Mostra documenti condivisi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="707"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="707" />
         <source>contact_details_trust_title</source>
-        <extracomment>&quot;Confiance&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Confiance"</extracomment>
+        <translation>Fiducia</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="714"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="714" />
         <source>contact_dialog_devices_trust_title</source>
-        <extracomment>&quot;Niveau de confiance - Appareils vérifiés&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Niveau de confiance - Appareils vérifiés"</extracomment>
+        <translation>Livello di fiducia - Dispositivi verificati</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="723"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="723" />
         <source>contact_details_no_device_found</source>
-        <extracomment>&quot;Aucun appareil&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucun appareil"</extracomment>
+        <translation>Nessun dispositivo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="748"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="748" />
         <source>contact_device_without_name</source>
-        <extracomment>&quot;Appareil inconnu&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appareil inconnu"</extracomment>
+        <translation>Dispositivo sconosciuto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="769"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="769" />
         <source>contact_make_call_check_device_trust</source>
-        <extracomment>&quot;Vérifier&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vérifier"</extracomment>
+        <translation>Verifica</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="771"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="771" />
         <source>verify_device_accessible_name</source>
         <extracomment>Verify %1 device</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Verifica il dispositivo %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="797"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="797" />
         <source>contact_details_actions_title</source>
-        <extracomment>&quot;Autres actions&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Autres actions"</extracomment>
+        <translation>Altre azioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="827"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="827" />
         <source>contact_details_remove_from_favourites</source>
-        <extracomment>&quot;Retirer des favoris&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Retirer des favoris"</extracomment>
+        <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="829"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="829" />
         <source>contact_details_add_to_favourites</source>
-        <extracomment>&quot;Ajouter aux favoris&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter aux favoris"</extracomment>
+        <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="846"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="846" />
         <source>contact_details_share</source>
-        <extracomment>&quot;Partager&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Partager"</extracomment>
+        <translation>Condividi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="857"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="857" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="859"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="859" />
         <source>contact_details_share_error_mesage</source>
-        <extracomment>&quot;La création du fichier vcard a échoué&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"La création du fichier vcard a échoué"</extracomment>
+        <translation>Creazione della vCard non riuscita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="864"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="864" />
         <source>contact_details_share_success_title</source>
-        <extracomment>&quot;VCard créée&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"VCard créée"</extracomment>
+        <translation>VCard creata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="866"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="866" />
         <source>contact_details_share_success_mesage</source>
-        <extracomment>&quot;VCard du contact enregistrée dans %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"VCard du contact enregistrée dans %1"</extracomment>
+        <translation>La vCard del contatto è stata salvata in %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="869"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="869" />
         <source>contact_details_share_email_title</source>
-        <extracomment>&quot;Partage de contact&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Partage de contact"</extracomment>
+        <translation>Condividi contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="910"/>
+        <location filename="../../view/Page/Main/Contact/ContactPage.qml" line="910" />
         <source>contact_details_delete</source>
-        <extracomment>&quot;Supprimer ce contact&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer ce contact"</extracomment>
+        <translation>Elimina contatto</translation>
     </message>
 </context>
 <context>
     <name>ContactSharedFiles</name>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactSharedFiles.qml" line="22"/>
+        <location filename="../../view/Page/Form/Contact/ContactSharedFiles.qml" line="22" />
         <source>contact_shared_medias_title</source>
-        <extracomment>&quot;Shared medias&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Shared medias"</extracomment>
+        <translation>Media condivisi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactSharedFiles.qml" line="24"/>
+        <location filename="../../view/Page/Form/Contact/ContactSharedFiles.qml" line="24" />
         <source>contact_shared_documents_title</source>
-        <extracomment>&quot;Shared documents&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Shared documents"</extracomment>
+        <translation>Documenti condivisi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Contact/ContactSharedFiles.qml" line="45"/>
+        <location filename="../../view/Page/Form/Contact/ContactSharedFiles.qml" line="45" />
         <source>close_accessible_name</source>
         <extracomment>Close %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiudi %1</translation>
     </message>
 </context>
 <context>
     <name>ContactsSettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="14"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="14" />
         <source>settings_contacts_ldap_title</source>
         <extracomment>Annuaires LDAP</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Server LDAP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="16"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="16" />
         <source>settings_contacts_ldap_subtitle</source>
-        <extracomment>&quot;Ajouter vos annuaires LDAP pour pouvoir effectuer des recherches dans la barre de recherche.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter vos annuaires LDAP pour pouvoir effectuer des recherches dans la barre de recherche."</extracomment>
+        <translation>Aggiungi i tuoi server LDAP per poter effettuare ricerche nella barra di ricerca magica.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="21"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="21" />
         <source>settings_contacts_carddav_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Rubrica CardDAV</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="22"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="22" />
         <source>settings_contacts_carddav_subtitle</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi una rubrica CardDAV per sincronizzare i tuoi contatti Linphone con una rubrica di terze parti.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="42"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="42" />
         <source>settings_contacts_add_ldap_server_title</source>
-        <extracomment>&quot;Ajouter un annuaire LDAP&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter un annuaire LDAP"</extracomment>
+        <translation>Aggiungi un server LDAP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="44"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="44" />
         <source>settings_contacts_edit_ldap_server_title</source>
-        <extracomment>&quot;Modifier un annuaire LDAP&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Modifier un annuaire LDAP"</extracomment>
+        <translation>Modifica un server LDAP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="46"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="46" />
         <source>edit_ldap_server_accessible_name</source>
-        <extracomment>&quot;Editer le serveur LDAP %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Editer le serveur LDAP %1"</extracomment>
+        <translation>Modifica il server LDAP %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="48"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="48" />
         <source>use_ldap_server_accessible_name</source>
-        <extracomment>&quot;Utiliser le serveur LDAP %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Utiliser le serveur LDAP %1"</extracomment>
+        <translation>Usa il server LDAP %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="73"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="73" />
         <source>settings_contacts_add_carddav_server_title</source>
-        <extracomment>&quot;Ajouter un carnet d&apos;adresse CardDAV&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter un carnet d'adresse CardDAV"</extracomment>
+        <translation>Aggiungi una rubrica CardDAV</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="75"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="75" />
         <source>settings_contacts_edit_carddav_server_title</source>
-        <extracomment>&quot;Modifier un carnet d&apos;adresse CardDAV&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Modifier un carnet d'adresse CardDAV"</extracomment>
+        <translation>Modifica una rubrica CardDAV</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="77"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="77" />
         <source>edit_cardav_server_accessible_name</source>
-        <extracomment>&quot;Editer le carnet d&apos;adresses CardDAV %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Editer le carnet d'adresses CardDAV %1"</extracomment>
+        <translation>Modifica la rubrica CardDAV %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="79"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsLayout.qml" line="79" />
         <source>use_cardav_server_accessible_name</source>
-        <extracomment>&quot;Utiliser le d&apos;adresses CardDAV %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Utiliser le d'adresses CardDAV %1"</extracomment>
+        <translation>Usa la rubrica CardDAV %1</translation>
     </message>
 </context>
 <context>
     <name>ContactsSettingsProviderLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsProviderLayout.qml" line="100"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsProviderLayout.qml" line="100" />
         <source>information_popup_success_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Operazione riuscita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsProviderLayout.qml" line="102"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsProviderLayout.qml" line="102" />
         <source>information_popup_changes_saved</source>
-        <extracomment>&quot;Les changements ont été sauvegardés&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Les changements ont été sauvegardés"</extracomment>
+        <translation>Le modifiche sono state salvate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/ContactsSettingsProviderLayout.qml" line="124"/>
+        <location filename="../../view/Page/Layout/Settings/ContactsSettingsProviderLayout.qml" line="124" />
         <source>add</source>
-        <extracomment>&quot;Ajouter&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter"</extracomment>
+        <translation>Aggiungi</translation>
     </message>
 </context>
 <context>
     <name>ConversationInfos</name>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="208"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="208" />
         <source>one_one_infos_call</source>
-        <extracomment>&quot;Appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel"</extracomment>
+        <translation>Chiama</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="222"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="222" />
         <source>one_one_infos_unmute</source>
-        <extracomment>&quot;Sourdine&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Sourdine"</extracomment>
+        <translation>Riattiva audio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="222"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="222" />
         <source>one_one_infos_mute</source>
-        <translation type="unfinished"></translation>
+        <translation>Disattiva audio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="289"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="289" />
         <source>group_infos_participants</source>
-        <translation type="unfinished"></translation>
+        <translation>Partecipanti (%1)</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="306"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="306" />
         <source>group_infos_media_docs</source>
         <extracomment>Medias &amp; documents</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Contenuti multimediali e documenti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="312"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="312" />
         <source>group_infos_shared_medias</source>
         <extracomment>Shared medias</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Contenuti multimediali condivisi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="323"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="323" />
         <source>group_infos_shared_docs</source>
         <extracomment>Shared documents</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Documenti condivisi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="336"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="336" />
         <source>group_infos_other_actions</source>
         <extracomment>Other actions</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Altre azioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="342"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="342" />
         <source>group_infos_ephemerals</source>
-        <translation type="unfinished"></translation>
+        <translation>Messaggi effimeri: </translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="342"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="342" />
         <source>group_infos_enable_ephemerals</source>
-        <translation type="unfinished"></translation>
+        <translation>Attiva i messaggi effimeri</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="244"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="244" />
         <source>group_infos_meeting</source>
         <extracomment>Schedule a meeting</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Pianifica una riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="353"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="353" />
         <source>group_infos_leave_room</source>
         <extracomment>Leave chat room</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Abbandona la chat di gruppo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="358"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="358" />
         <source>group_infos_leave_room_toast_title</source>
         <extracomment>Leave Chat Room ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Abbandonare la chat di gruppo?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="360"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="360" />
         <source>group_infos_leave_room_toast_message</source>
         <extracomment>All the messages will be removed from the chat room. Do you want to continue ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Tutti i messaggi verranno rimossi dalla chat di gruppo. Vuoi continuare?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="373"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="373" />
         <source>group_infos_delete_history</source>
         <extracomment>Delete history</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Elimina cronologia</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="378"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="378" />
         <source>group_infos_delete_history_toast_title</source>
         <extracomment>Delete history ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Eliminare la cronologia?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="380"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="380" />
         <source>group_infos_delete_history_toast_message</source>
         <extracomment>All the messages will be removed from the chat room. Do you want to continue ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Tutti i messaggi verranno rimossi dalla chat di gruppo. Vuoi continuare?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="247"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="247" />
         <source>one_one_infos_open_contact</source>
         <extracomment>Show contact</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Mostra contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="249"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="249" />
         <source>one_one_infos_create_contact</source>
         <extracomment>Create contact</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Crea contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="394"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="394" />
         <source>one_one_infos_ephemerals</source>
-        <translation type="unfinished"></translation>
+        <translation>Messaggi effimeri: </translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="394"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="394" />
         <source>one_one_infos_enable_ephemerals</source>
-        <translation type="unfinished"></translation>
+        <translation>Attiva i messaggi effimeri</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="404"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="404" />
         <source>one_one_infos_delete_history</source>
-        <translation type="unfinished"></translation>
+        <translation>Elimina cronologia</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="409"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="409" />
         <source>one_one_infos_delete_history_toast_title</source>
         <extracomment>Delete history ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Eliminare la cronologia?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="411"/>
+        <location filename="../../view/Page/Layout/Chat/ConversationInfos.qml" line="411" />
         <source>one_one_infos_delete_history_toast_message</source>
         <extracomment>All the messages will be removed from the chat room. Do you want to continue ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Tutti i messaggi verranno rimossi dalla chat. Vuoi continuare?</translation>
     </message>
 </context>
 <context>
@@ -3667,980 +3699,982 @@ Error</extracomment>
     </message>
     <message>
         <source>fetching_config_failed_error_message</source>
-        <extracomment>&quot;Remote provisioning cannot be retrieved&quot;</extracomment>
+        <extracomment>"Remote provisioning cannot be retrieved"</extracomment>
         <translation type="vanished">Remote provisioning cannot be retrieved</translation>
     </message>
     <message>
-        <location filename="../../model/core/CoreModel.cpp" line="250"/>
+        <location filename="../../model/core/CoreModel.cpp" line="250" />
         <source>fetching_config_empty_path_failure_error_message</source>
-        <extracomment>&quot;Could not get file path for fetching config, return&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Could not get file path for fetching config, return"</extracomment>
+        <translation>Impossibile ottenere il percorso del file per recuperare la configurazione, uscita</translation>
     </message>
 </context>
 <context>
     <name>CreationFormLayout</name>
     <message>
-        <location filename="../../view/Control/Container/CreationFormLayout.qml" line="47"/>
+        <location filename="../../view/Control/Container/CreationFormLayout.qml" line="47" />
         <source>search_bar_look_for_contact_text</source>
-        <extracomment>&quot;Rechercher un contact&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Rechercher un contact"</extracomment>
+        <translation>Cerca contatto</translation>
     </message>
 </context>
 <context>
     <name>DebugSettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="33"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="33" />
         <source>settings_debug_clean_logs_message</source>
-        <extracomment>&quot;Les traces de débogage seront supprimées. Souhaitez-vous continuer ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Les traces de débogage seront supprimées. Souhaitez-vous continuer ?"</extracomment>
+        <translation>Le tracce di debug verranno eliminate. Vuoi continuare?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="44"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="44" />
         <source>settings_debug_share_logs_message</source>
-        <extracomment>&quot;Les traces de débogage ont été téléversées. Comment souhaitez-vous partager le lien ? &quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Les traces de débogage ont été téléversées. Comment souhaitez-vous partager le lien ? "</extracomment>
+        <translation>Le tracce di debug sono state caricate. Come vuoi condividere il link?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="48"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="48" />
         <source>settings_debug_clipboard</source>
-        <extracomment>&quot;Presse-papier&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Presse-papier"</extracomment>
+        <translation>Appunti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="57"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="57" />
         <source>settings_debug_email</source>
-        <extracomment>&quot;E-Mail&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"E-Mail"</extracomment>
+        <translation>E-mail</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="63"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="63" />
         <source>debug_settings_trace</source>
-        <extracomment>&quot;Traces %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Traces %1"</extracomment>
+        <translation>Tracce %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="69"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="69" />
         <source>information_popup_email_sharing_failed</source>
-        <extracomment>&quot;Le partage par mail a échoué. Veuillez envoyer le lien %1 directement à l&apos;adresse %2.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le partage par mail a échoué. Veuillez envoyer le lien %1 directement à l'adresse %2."</extracomment>
+        <translation>Condivisione via email non riuscita. Invia il link %1 direttamente a %2.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="67"/>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="204"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="67" />
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="204" />
         <source>information_popup_error_title</source>
         <extracomment>Une erreur est survenue.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Si è verificato un errore.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="81"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="81" />
         <source>settings_debug_enable_logs_title</source>
-        <extracomment>&quot;Activer les traces de débogage&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Activer les traces de débogage"</extracomment>
+        <translation>Attiva tracce di debug</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="87"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="87" />
         <source>settings_debug_enable_full_logs_title</source>
-        <extracomment>&quot;Activer les traces de débogage intégrales&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Activer les traces de débogage intégrales"</extracomment>
+        <translation>Attiva log completi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="97"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="97" />
         <source>settings_debug_delete_logs_title</source>
-        <extracomment>&quot;Supprimer les traces&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer les traces"</extracomment>
+        <translation>Elimina tracce di debug</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="105"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="105" />
         <source>settings_debug_share_logs_title</source>
-        <extracomment>&quot;Partager les traces&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Partager les traces"</extracomment>
+        <translation>Condividi tracce di debug</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="109"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="109" />
         <source>settings_debug_share_logs_loading_message</source>
-        <extracomment>&quot;Téléversement des traces en cours …&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Téléversement des traces en cours …"</extracomment>
+        <translation>Caricamento tracce in corso…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="127"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="127" />
         <source>settings_debug_app_version_title</source>
-        <extracomment>&quot;Version de l&apos;application&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Version de l'application"</extracomment>
+        <translation>Versione app</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="134"/>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="158"/>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="182"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="134" />
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="158" />
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="182" />
         <source>copied</source>
         <extracomment>Copied</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Copiato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="136"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="136" />
         <source>settings_debug_app_version_copied_message</source>
         <extracomment>App version has been copied to clipboard</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>La versione dell'app è stata copiata negli appunti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="142"/>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="166"/>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="190"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="142" />
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="166" />
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="190" />
         <source>settings_debug_copy_tooltip</source>
         <extracomment>Copy text</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Copia testo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="151"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="151" />
         <source>settings_debug_sdk_version_title</source>
-        <extracomment>&quot;Version du SDK&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Version du SDK"</extracomment>
+        <translation>Versione SDK</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="160"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="160" />
         <source>settings_debug_sdk_version_copied_message</source>
         <extracomment>SDK version has been copied to clipboard</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>La versione SDK è stata copiata negli appunti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="176"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="176" />
         <source>settings_debug_qt_version_title</source>
-        <extracomment>&quot;Qt Version&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Qt Version"</extracomment>
+        <translation>Versione Qt</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="184"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="184" />
         <source>settings_debug_qt_version_copied_message</source>
         <extracomment>Qt version has been copied to clipboard</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>La versione Qt è stata copiata negli appunti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="206"/>
+        <location filename="../../view/Page/Layout/Settings/DebugSettingsLayout.qml" line="206" />
         <source>settings_debug_share_logs_error</source>
-        <extracomment>&quot;Le téléversement des traces a échoué. Vous pouvez partager les fichiers de trace directement depuis le répertoire suivant : %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le téléversement des traces a échoué. Vous pouvez partager les fichiers de trace directement depuis le répertoire suivant : %1"</extracomment>
+        <translation>Caricamento tracce non riuscito. Puoi condividere i file di traccia direttamente dalla seguente cartella: %1</translation>
     </message>
 </context>
 <context>
     <name>DecoratedTextField</name>
     <message>
-        <location filename="../../view/Control/Input/DecoratedTextField.qml" line="60"/>
+        <location filename="../../view/Control/Input/DecoratedTextField.qml" line="60" />
         <source>textfield_error_message_cannot_be_empty</source>
-        <extracomment>&quot;ne peut être vide&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"ne peut être vide"</extracomment>
+        <translation>non può essere vuoto</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Input/DecoratedTextField.qml" line="63"/>
+        <location filename="../../view/Control/Input/DecoratedTextField.qml" line="63" />
         <source>textfield_error_message_unknown_format</source>
-        <extracomment>&quot;Format non reconnu&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Format non reconnu"</extracomment>
+        <translation>Formato non riconosciuto</translation>
     </message>
 </context>
 <context>
     <name>Dialog</name>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/Dialog.qml" line="25"/>
-        <location filename="../../view/Control/Popup/Dialog/Dialog.qml" line="28"/>
+        <location filename="../../view/Control/Popup/Dialog/Dialog.qml" line="25" />
+        <location filename="../../view/Control/Popup/Dialog/Dialog.qml" line="28" />
         <source>dialog_confirm</source>
-        <extracomment>&quot;Confirmer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Confirmer"</extracomment>
+        <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/Dialog.qml" line="27"/>
-        <location filename="../../view/Control/Popup/Dialog/Dialog.qml" line="29"/>
+        <location filename="../../view/Control/Popup/Dialog/Dialog.qml" line="27" />
+        <location filename="../../view/Control/Popup/Dialog/Dialog.qml" line="29" />
         <source>dialog_cancel</source>
-        <extracomment>&quot;Annuler&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Annuler"</extracomment>
+        <translation>Annulla</translation>
     </message>
 </context>
 <context>
     <name>EncryptionSettings</name>
     <message>
-        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="23"/>
+        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="23" />
         <source>call_stats_media_encryption_title</source>
-        <extracomment>&quot;Encryption :&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Encryption :"</extracomment>
+        <translation>Crittografia:</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="36"/>
+        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="36" />
         <source>call_stats_media_encryption</source>
         <extracomment>Media encryption : %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Crittografia media: %1%2</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="47"/>
+        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="47" />
         <source>call_stats_zrtp_cipher_algo</source>
-        <extracomment>&quot;Algorithme de chiffrement : %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Algorithme de chiffrement : %1"</extracomment>
+        <translation>Algoritmo di crittografia: %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="56"/>
+        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="56" />
         <source>call_stats_zrtp_key_agreement_algo</source>
-        <extracomment>&quot;Algorithme d&apos;accord de clé : %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Algorithme d'accord de clé : %1"</extracomment>
+        <translation>Algoritmo di accordo sulla chiave: %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="65"/>
+        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="65" />
         <source>call_stats_zrtp_hash_algo</source>
-        <extracomment>&quot;Algorithme de hachage : %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Algorithme de hachage : %1"</extracomment>
+        <translation>Algoritmo di hash: %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="74"/>
+        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="74" />
         <source>call_stats_zrtp_auth_tag_algo</source>
-        <extracomment>&quot;Algorithme d&apos;authentification : %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Algorithme d'authentification : %1"</extracomment>
+        <translation>Algoritmo di autenticazione: %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="83"/>
+        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="83" />
         <source>call_stats_zrtp_sas_algo</source>
-        <extracomment>&quot;Algorithme SAS : %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Algorithme SAS : %1"</extracomment>
+        <translation>Algoritmo SAS: %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="99"/>
+        <location filename="../../view/Control/Form/Settings/EncryptionSettings.qml" line="99" />
         <source>call_zrtp_validation_button_label</source>
-        <extracomment>&quot;Validation chiffrement&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Validation chiffrement"</extracomment>
+        <translation>Convalida crittografia</translation>
     </message>
 </context>
 <context>
     <name>EphemeralSettings</name>
     <message>
-        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="58"/>
+        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="58" />
         <source>title</source>
-        <translation type="unfinished"></translation>
+        <translation>Messaggi effimeri</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="77"/>
+        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="77" />
         <source>explanations</source>
-        <translation type="unfinished"></translation>
+        <translation>Attivando i messaggi effimeri in questa chat, i messaggi inviati verranno eliminati automaticamente dopo il periodo definito.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="22"/>
+        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="22" />
         <source>one_minute</source>
-        <translation type="unfinished"></translation>
+        <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="23"/>
+        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="23" />
         <source>one_hour</source>
-        <translation type="unfinished"></translation>
+        <translation>1 ora</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="24"/>
+        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="24" />
         <source>one_day</source>
-        <translation type="unfinished"></translation>
+        <translation>1 giorno</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="25"/>
+        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="25" />
         <source>one_week</source>
-        <translation type="unfinished"></translation>
+        <translation>1 settimana</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="26"/>
+        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="26" />
         <source>disabled</source>
         <translation>Disattivato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="35"/>
+        <location filename="../../view/Page/Layout/Chat/EphemeralSettings.qml" line="35" />
         <source>custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Personalizzato: </translation>
     </message>
 </context>
 <context>
     <name>EventLogCore</name>
     <message>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="113"/>
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="113" />
         <source>conference_created_event</source>
-        <translation type="unfinished"></translation>
+        <translation>Sei entrato nel gruppo</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="119"/>
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="119" />
         <source>conference_created_terminated</source>
-        <translation type="unfinished"></translation>
+        <translation>Hai lasciato il gruppo</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="123"/>
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="123" />
         <source>conference_participant_added_event</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 è entrato</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="127"/>
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="127" />
         <source>conference_participant_removed_event</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 non fa più parte della conversazione</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="164"/>
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="164" />
         <source>conference_participant_set_admin_event</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 è ora amministratore</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="168"/>
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="168" />
         <source>conference_participant_unset_admin_event</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 non è più amministratore</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="136"/>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="138"/>
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="136" />
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="138" />
         <source>conference_security_event</source>
-        <translation type="unfinished"></translation>
+        <translation>Livello di sicurezza ridotto da %1</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="145"/>
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="145" />
         <source>conference_ephemeral_message_enabled_event</source>
-        <translation type="unfinished"></translation>
+        <translation>Messaggi effimeri attivati
+Scadenza: %1</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="156"/>
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="156" />
         <source>conference_ephemeral_message_disabled_event</source>
-        <translation type="unfinished"></translation>
+        <translation>Messaggi effimeri disattivati</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="160"/>
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="160" />
         <source>conference_subject_changed_event</source>
-        <translation type="unfinished"></translation>
+        <translation>Nuovo oggetto: %1</translation>
     </message>
     <message>
-        <location filename="../../core/chat/message/EventLogCore.cpp" line="151"/>
+        <location filename="../../core/chat/message/EventLogCore.cpp" line="151" />
         <source>conference_ephemeral_message_lifetime_changed_event</source>
-        <translation type="unfinished"></translation>
+        <translation>Messaggi effimeri aggiornati
+Scadenza: %1</translation>
     </message>
 </context>
 <context>
     <name>FriendCore</name>
     <message>
-        <location filename="../../core/friend/FriendCore.cpp" line="31"/>
-        <location filename="../../core/friend/FriendCore.cpp" line="77"/>
-        <location filename="../../core/friend/FriendCore.cpp" line="197"/>
-        <location filename="../../core/friend/FriendCore.cpp" line="433"/>
-        <location filename="../../core/friend/FriendCore.cpp" line="598"/>
+        <location filename="../../core/friend/FriendCore.cpp" line="31" />
+        <location filename="../../core/friend/FriendCore.cpp" line="77" />
+        <location filename="../../core/friend/FriendCore.cpp" line="197" />
+        <location filename="../../core/friend/FriendCore.cpp" line="433" />
+        <location filename="../../core/friend/FriendCore.cpp" line="598" />
         <source>sip_address</source>
-        <extracomment>&quot;Adresse SIP&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Adresse SIP"</extracomment>
+        <translation>Indirizzo SIP</translation>
     </message>
     <message>
-        <location filename="../../core/friend/FriendCore.cpp" line="33"/>
-        <location filename="../../core/friend/FriendCore.cpp" line="85"/>
-        <location filename="../../core/friend/FriendCore.cpp" line="205"/>
+        <location filename="../../core/friend/FriendCore.cpp" line="33" />
+        <location filename="../../core/friend/FriendCore.cpp" line="85" />
+        <location filename="../../core/friend/FriendCore.cpp" line="205" />
         <source>device_id</source>
-        <extracomment>&quot;Téléphone&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Téléphone"</extracomment>
+        <translation>Telefono</translation>
     </message>
     <message>
-        <location filename="../../core/friend/FriendCore.cpp" line="429"/>
+        <location filename="../../core/friend/FriendCore.cpp" line="429" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../core/friend/FriendCore.cpp" line="431"/>
+        <location filename="../../core/friend/FriendCore.cpp" line="431" />
         <source>information_popup_invalid_address_message</source>
-        <extracomment>&quot;Adresse invalide&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Adresse invalide"</extracomment>
+        <translation>Indirizzo non valido</translation>
     </message>
 </context>
 <context>
     <name>GroupChatInfoParticipants</name>
     <message>
-        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="204"/>
+        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="204" />
         <source>group_infos_manage_participants_title</source>
-        <extracomment>&quot;Gérer des participants&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Gérer des participants"</extracomment>
+        <translation>Gestisci partecipanti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="92"/>
+        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="92" />
         <source>group_infos_participant_is_admin</source>
-        <translation type="unfinished"></translation>
+        <translation>Amministratore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="122"/>
+        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="122" />
         <source>menu_see_existing_contact</source>
-        <extracomment>&quot;Show contact&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Show contact"</extracomment>
+        <translation>Mostra contatto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="124"/>
+        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="124" />
         <source>menu_add_address_to_contacts</source>
-        <extracomment>&quot;Add to contacts&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Add to contacts"</extracomment>
+        <translation>Aggiungi ai contatti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="141"/>
+        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="141" />
         <source>group_infos_give_admin_rights</source>
-        <translation type="unfinished"></translation>
+        <translation>Concedi diritti di amministratore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="141"/>
+        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="141" />
         <source>group_infos_remove_admin_rights</source>
-        <translation type="unfinished"></translation>
+        <translation>Rimuovi diritti di amministratore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="152"/>
+        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="152" />
         <source>group_infos_copy_sip_address</source>
-        <translation type="unfinished"></translation>
+        <translation>Copia indirizzo SIP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="172"/>
+        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="172" />
         <source>group_infos_remove_participant</source>
-        <translation type="unfinished"></translation>
+        <translation>Rimuovi partecipante</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="179"/>
+        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="179" />
         <source>group_infos_remove_participants_toast_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Rimuovere il partecipante?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="180"/>
+        <location filename="../../view/Page/Layout/Chat/GroupChatInfoParticipants.qml" line="180" />
         <source>group_infos_remove_participants_toast_message</source>
-        <translation type="unfinished"></translation>
+        <translation>Il partecipante verrà rimosso dalla chat di gruppo.</translation>
     </message>
 </context>
 <context>
     <name>GroupCreationFormLayout</name>
     <message>
-        <location filename="../../view/Control/Container/GroupCreationFormLayout.qml" line="40"/>
+        <location filename="../../view/Control/Container/GroupCreationFormLayout.qml" line="40" />
         <source>return_accessible_name</source>
         <extracomment>Return</extracomment>
         <translation>indietro</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/GroupCreationFormLayout.qml" line="76"/>
-        <location filename="../../view/Control/Container/GroupCreationFormLayout.qml" line="86"/>
+        <location filename="../../view/Control/Container/GroupCreationFormLayout.qml" line="76" />
+        <location filename="../../view/Control/Container/GroupCreationFormLayout.qml" line="86" />
         <source>group_start_dialog_subject_hint</source>
-        <extracomment>&quot;Nom du groupe&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nom du groupe"</extracomment>
+        <translation>Nome del gruppo</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Container/GroupCreationFormLayout.qml" line="78"/>
+        <location filename="../../view/Control/Container/GroupCreationFormLayout.qml" line="78" />
         <source>required</source>
-        <extracomment>&quot;Requis&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Requis"</extracomment>
+        <translation>Obbligatorio</translation>
     </message>
 </context>
 <context>
     <name>HelpPage</name>
     <message>
-        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="43"/>
+        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="43" />
         <source>help_title</source>
-        <extracomment>&quot;Aide&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aide"</extracomment>
+        <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="73"/>
-        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="142"/>
+        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="73" />
+        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="142" />
         <source>help_about_title</source>
-        <extracomment>&quot;À propos de %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"À propos de %1"</extracomment>
+        <translation>Informazioni su %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="87"/>
+        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="87" />
         <source>help_about_privacy_policy_title</source>
-        <extracomment>&quot;Règles de confidentialité&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Règles de confidentialité"</extracomment>
+        <translation>Informativa sulla privacy</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="89"/>
+        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="89" />
         <source>help_about_privacy_policy_subtitle</source>
         <extracomment>Quelles informations %1 collecte et utilise</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Quali informazioni raccoglie e utilizza %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="101"/>
+        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="101" />
         <source>help_about_version_title</source>
-        <extracomment>&quot;Version&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Version"</extracomment>
+        <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="109"/>
+        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="109" />
         <source>help_check_for_update_button_label</source>
         <extracomment>Check update</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Controlla aggiornamenti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="117"/>
+        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="117" />
         <source>help_about_gpl_licence_title</source>
-        <extracomment>&quot;Licences GPLv3&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Licences GPLv3"</extracomment>
+        <translation>Licenze GPLv3</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="129"/>
+        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="129" />
         <source>help_about_contribute_translations_title</source>
-        <extracomment>&quot;Contribuer à la traduction de %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Contribuer à la traduction de %1"</extracomment>
+        <translation>Contribuisci alla traduzione di %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="155"/>
+        <location filename="../../view/Page/Main/Help/HelpPage.qml" line="155" />
         <source>help_troubleshooting_title</source>
-        <extracomment>&quot;Dépannage&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Dépannage"</extracomment>
+        <translation>Risoluzione dei problemi</translation>
     </message>
 </context>
 <context>
     <name>LdapSettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="17"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="17" />
         <source>settings_contacts_ldap_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Server LDAP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="18"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="18" />
         <source>settings_contacts_ldap_subtitle</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiungi i tuoi server LDAP per poterli cercare nella barra di ricerca.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="30"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="30" />
         <source>information_popup_success_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Operazione riuscita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="32"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="32" />
         <source>settings_contacts_ldap_success_toast</source>
-        <extracomment>&quot;L&apos;annuaire LDAP a été sauvegardé&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"L'annuaire LDAP a été sauvegardé"</extracomment>
+        <translation>Il server LDAP è stato salvato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="36"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="36" />
         <source>settings_contacts_ldap_error_toast</source>
-        <extracomment>&quot;Une erreur s&apos;est produite, la configuration LDAP n&apos;a pas été sauvegardée !&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Une erreur s'est produite, la configuration LDAP n'a pas été sauvegardée !"</extracomment>
+        <translation>Si è verificato un errore, la configurazione LDAP non è stata salvata.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="34"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="34" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="56"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="56" />
         <source>settings_contacts_ldap_delete_confirmation_message</source>
-        <extracomment>&quot;Supprimer l&apos;annuaire LDAP ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer l'annuaire LDAP ?"</extracomment>
+        <translation>Eliminare il server LDAP?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="67"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="67" />
         <source>delete_ldap_server_accessible_name</source>
         <extracomment>Delete LDAP server</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Elimina server LDAP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="85"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="85" />
         <source>settings_contacts_ldap_server_url_title</source>
-        <extracomment>&quot;URL du serveur (ne peut être vide)&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"URL du serveur (ne peut être vide)"</extracomment>
+        <translation>URL del server (obbligatorio)</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="93"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="93" />
         <source>settings_contacts_ldap_bind_dn_title</source>
-        <extracomment>&quot;Bind DN&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Bind DN"</extracomment>
+        <translation>Bind DN</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="102"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="102" />
         <source>settings_contacts_ldap_password_title</source>
-        <extracomment>&quot;Mot de passe&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Mot de passe"</extracomment>
+        <translation>Password</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="108"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="108" />
         <source>settings_contacts_ldap_use_tls_title</source>
-        <extracomment>&quot;Utiliser TLS&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Utiliser TLS"</extracomment>
+        <translation>Usa TLS</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="116"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="116" />
         <source>settings_contacts_ldap_search_base_title</source>
-        <extracomment>&quot;Base de recherche (ne peut être vide)&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Base de recherche (ne peut être vide)"</extracomment>
+        <translation>Base di ricerca (obbligatoria)</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="124"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="124" />
         <source>settings_contacts_ldap_search_filter_title</source>
-        <extracomment>&quot;Filtre&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Filtre"</extracomment>
+        <translation>Filtro</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="133"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="133" />
         <source>settings_contacts_ldap_max_results_title</source>
-        <extracomment>&quot;Nombre maximum de résultats&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nombre maximum de résultats"</extracomment>
+        <translation>Numero massimo di risultati</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="142"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="142" />
         <source>settings_contacts_ldap_request_delay_title</source>
-        <extracomment>&quot;Délai entre 2 requêtes (en millisecondes)&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Délai entre 2 requêtes (en millisecondes)"</extracomment>
+        <translation>Ritardo tra due richieste (in millisecondi)</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="150"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="150" />
         <source>settings_contacts_ldap_request_timeout_title</source>
-        <extracomment>&quot;Durée maximun (en secondes)&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Durée maximun (en secondes)"</extracomment>
+        <translation>Timeout (in secondi)</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="159"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="159" />
         <source>settings_contacts_ldap_min_characters_title</source>
-        <extracomment>&quot;Nombre minimum de caractères pour la requête&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nombre minimum de caractères pour la requête"</extracomment>
+        <translation>Numero minimo di caratteri per la ricerca</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="168"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="168" />
         <source>settings_contacts_ldap_name_attributes_title</source>
-        <extracomment>&quot;Attributs de nom&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Attributs de nom"</extracomment>
+        <translation>Attributi nome</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="176"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="176" />
         <source>settings_contacts_ldap_sip_attributes_title</source>
-        <extracomment>&quot;Attributs SIP&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Attributs SIP"</extracomment>
+        <translation>Attributi SIP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="184"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="184" />
         <source>settings_contacts_ldap_sip_domain_title</source>
-        <extracomment>&quot;Domaine SIP&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Domaine SIP"</extracomment>
+        <translation>Dominio SIP</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="190"/>
+        <location filename="../../view/Page/Layout/Settings/LdapSettingsLayout.qml" line="190" />
         <source>settings_contacts_ldap_debug_title</source>
-        <extracomment>&quot;Débogage&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Débogage"</extracomment>
+        <translation>Debug</translation>
     </message>
 </context>
 <context>
     <name>LoadingPopup</name>
     <message>
-        <location filename="../../view/Control/Popup/Loading/LoadingPopup.qml" line="42"/>
+        <location filename="../../view/Control/Popup/Loading/LoadingPopup.qml" line="42" />
         <source>cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annulla</translation>
     </message>
 </context>
 <context>
     <name>LoginForm</name>
     <message>
-        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="17"/>
-        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="27"/>
+        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="17" />
+        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="27" />
         <source>username</source>
-        <extracomment>Nom d&apos;utilisateur : username</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>Nom d'utilisateur : username</extracomment>
+        <translation>Nome utente</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="36"/>
-        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="46"/>
+        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="36" />
+        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="46" />
         <source>password</source>
         <extracomment>Mot de passe</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Password</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="27"/>
+        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="27" />
         <source>mandatory_field_accessible_name</source>
-        <extracomment>&quot;%1 mandatory&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"%1 mandatory"</extracomment>
+        <translation>%1 obbligatorio</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="69"/>
-        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="75"/>
+        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="69" />
+        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="75" />
         <source>assistant_account_login</source>
-        <extracomment>&quot;Connexion&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Connexion"</extracomment>
+        <translation>Connessione</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="114"/>
+        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="114" />
         <source>assistant_account_login_missing_username</source>
-        <extracomment>&quot;Veuillez saisir un nom d&apos;utilisateur&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Veuillez saisir un nom d'utilisateur"</extracomment>
+        <translation>Inserisci un nome utente</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="117"/>
+        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="117" />
         <source>assistant_account_login_missing_password</source>
-        <extracomment>&quot;Veuillez saisir un mot de passe&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Veuillez saisir un mot de passe"</extracomment>
+        <translation>Inserisci una password</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="131"/>
+        <location filename="../../view/Control/Form/Login/LoginForm.qml" line="131" />
         <source>assistant_forgotten_password</source>
-        <extracomment>&quot;Mot de passe oublié ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Mot de passe oublié ?"</extracomment>
+        <translation>Password dimenticata?</translation>
     </message>
 </context>
 <context>
     <name>LoginLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="77"/>
-        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="141"/>
+        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="77" />
+        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="141" />
         <source>help_about_title</source>
         <extracomment>À propos de %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Informazioni su %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="87"/>
+        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="87" />
         <source>help_about_privacy_policy_title</source>
-        <extracomment>&quot;Politique de confidentialité&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Politique de confidentialité"</extracomment>
+        <translation>Informativa sulla privacy</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="89"/>
+        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="89" />
         <source>help_about_privacy_policy_link</source>
-        <extracomment>&quot;Visiter notre potilique de confidentialité&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Visiter notre potilique de confidentialité"</extracomment>
+        <translation>Visita la nostra informativa sulla privacy</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="96"/>
+        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="96" />
         <source>help_about_version_title</source>
-        <extracomment>&quot;Version&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Version"</extracomment>
+        <translation>Versione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="102"/>
+        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="102" />
         <source>help_about_licence_title</source>
-        <extracomment>&quot;Licence&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Licence"</extracomment>
+        <translation>Licenza</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="108"/>
+        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="108" />
         <source>help_about_copyright_title</source>
-        <extracomment>&quot;Copyright</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Copyright</extracomment>
+        <translation>Copyright</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="119"/>
+        <location filename="../../view/Page/Layout/Login/LoginLayout.qml" line="119" />
         <source>close</source>
-        <extracomment>&quot;Fermer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Fermer"</extracomment>
+        <translation>Chiudi</translation>
     </message>
 </context>
 <context>
     <name>LoginPage</name>
     <message>
-        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="31"/>
+        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="31" />
         <source>return_accessible_name</source>
         <extracomment>Return</extracomment>
         <translation>indietro</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="45"/>
+        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="45" />
         <source>assistant_account_login</source>
         <extracomment>Connexion</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Connessione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="63"/>
+        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="63" />
         <source>assistant_no_account_yet</source>
-        <extracomment>&quot;Pas encore de compte ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Pas encore de compte ?"</extracomment>
+        <translation>Non hai ancora un account?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="71"/>
+        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="71" />
         <source>assistant_account_register</source>
-        <extracomment>&quot;S&apos;inscrire&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"S'inscrire"</extracomment>
+        <translation>Registrati</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="97"/>
+        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="97" />
         <source>assistant_login_third_party_sip_account_title</source>
-        <extracomment>&quot;Compte SIP tiers&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Compte SIP tiers"</extracomment>
+        <translation>Account SIP di terze parti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="106"/>
+        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="106" />
         <source>assistant_login_remote_provisioning</source>
-        <extracomment>&quot;Configuration distante&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Configuration distante"</extracomment>
+        <translation>Configurazione remota</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="134"/>
+        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="134" />
         <source>assistant_login_download_remote_config</source>
-        <extracomment>&quot;Télécharger une configuration distante&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Télécharger une configuration distante"</extracomment>
+        <translation>Scarica una configurazione remota</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="136"/>
+        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="136" />
         <source>assistant_login_remote_provisioning_url</source>
-        <extracomment>&apos;Veuillez entrer le lien de configuration qui vous a été fourni :&apos;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>'Veuillez entrer le lien de configuration qui vous a été fourni :'</extracomment>
+        <translation>Inserisci il link di configurazione che ti è stato fornito:</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="138"/>
+        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="138" />
         <source>cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="143"/>
+        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="143" />
         <source>validate</source>
-        <extracomment>&quot;Valider&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Valider"</extracomment>
+        <translation>Conferma</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="155"/>
+        <location filename="../../view/Page/Form/Login/LoginPage.qml" line="155" />
         <source>settings_advanced_remote_provisioning_url</source>
-        <extracomment>&apos;Lien de configuration distante&apos;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>'Lien de configuration distante'</extracomment>
+        <translation>Link di configurazione remota</translation>
     </message>
     <message>
-        <location filename="../../core/login/LoginPage.cpp" line="86"/>
+        <location filename="../../core/login/LoginPage.cpp" line="86" />
         <source>default_account_connection_state_error_toast</source>
         <extracomment>Erreur durant la connexion, veuillez vérifier vos paramètres</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Errore durante la connessione</translation>
     </message>
 </context>
 <context>
     <name>MagicSearchList</name>
     <message>
-        <location filename="../../core/search/MagicSearchList.cpp" line="145"/>
+        <location filename="../../core/search/MagicSearchList.cpp" line="145" />
         <source>device_id</source>
-        <translation type="unfinished"></translation>
+        <translation>Telefono</translation>
     </message>
 </context>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="144"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="144" />
         <source>bottom_navigation_calls_label</source>
-        <extracomment>&quot;Appels&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appels"</extracomment>
+        <translation>Chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="146"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="146" />
         <source>open_calls_page_accessible_name</source>
-        <extracomment>&quot;Open calls page&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Open calls page"</extracomment>
+        <translation>Apri la pagina delle chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="152"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="152" />
         <source>bottom_navigation_contacts_label</source>
-        <extracomment>&quot;Contacts&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Contacts"</extracomment>
+        <translation>Contatti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="154"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="154" />
         <source>open_contacts_page_accessible_name</source>
-        <extracomment>&quot;Open contacts page&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Open contacts page"</extracomment>
+        <translation>Apri la pagina dei contatti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="160"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="160" />
         <source>bottom_navigation_conversations_label</source>
-        <extracomment>&quot;Conversations&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Conversations"</extracomment>
+        <translation>Conversazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="162"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="162" />
         <source>open_conversations_page_accessible_name</source>
-        <extracomment>&quot;Open conversations page&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Open conversations page"</extracomment>
+        <translation>Apri la pagina delle conversazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="169"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="169" />
         <source>bottom_navigation_meetings_label</source>
-        <extracomment>&quot;Réunions&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Réunions"</extracomment>
+        <translation>Riunioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="171"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="171" />
         <source>open_contact_page_accessible_name</source>
-        <extracomment>&quot;Open meetings page&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Open meetings page"</extracomment>
+        <translation>Apri la pagina delle riunioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="234"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="234" />
         <source>searchbar_placeholder_text</source>
-        <extracomment>&quot;Rechercher un contact, appeler %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Rechercher un contact, appeler %1"</extracomment>
+        <translation>Cerca un contatto, chiama %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="236"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="236" />
         <source>searchbar_placeholder_text_chat_feature_enabled</source>
-        <extracomment>&quot;ou envoyer un message …&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"ou envoyer un message …"</extracomment>
+        <translation>o invia un messaggio…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="319"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="319" />
         <source>searchbar_suggestions_accessible_name</source>
-        <extracomment>&quot;Searchbar suggestions&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Searchbar suggestions"</extracomment>
+        <translation>Suggerimenti della barra di ricerca</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="331"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="331" />
         <source>do_not_disturb_accessible_name</source>
-        <extracomment>&quot;Do not disturb&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Do not disturb"</extracomment>
+        <translation>Non disturbare</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="349"/>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="492"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="349" />
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="492" />
         <source>contact_presence_status_disable_do_not_disturb</source>
-        <extracomment>&quot;Désactiver ne pas déranger&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Désactiver ne pas déranger"</extracomment>
+        <translation>Disattiva non disturbare</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="403"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="403" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="405"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="405" />
         <source>no_voicemail_uri_error_message</source>
-        <extracomment>&quot;L&apos;URI de messagerie vocale n&apos;est pas définie.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"L'URI de messagerie vocale n'est pas définie."</extracomment>
+        <translation>L'URI della segreteria telefonica non è definito.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="418"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="418" />
         <source>account_list_accessible_name</source>
-        <extracomment>&quot;Account list&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Account list"</extracomment>
+        <translation>Elenco account</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="456"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="456" />
         <source>application_options_accessible_name</source>
-        <extracomment>&quot;Application options&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Application options"</extracomment>
+        <translation>Opzioni dell'applicazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="481"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="481" />
         <source>drawer_menu_manage_account</source>
         <extracomment>Mon compte</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Il mio account</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="494"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="494" />
         <source>contact_presence_status_enable_do_not_disturb</source>
-        <extracomment>&quot;Activer ne pas déranger&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Activer ne pas déranger"</extracomment>
+        <translation>Attiva non disturbare</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="509"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="509" />
         <source>settings_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="529"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="529" />
         <source>recordings_title</source>
-        <extracomment>&quot;Enregistrements&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Enregistrements"</extracomment>
+        <translation>Registrazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="547"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="547" />
         <source>help_title</source>
-        <extracomment>&quot;Aide&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aide"</extracomment>
+        <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="562"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="562" />
         <source>help_quit_title</source>
-        <extracomment>&quot;Quitter l&apos;application&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Quitter l'application"</extracomment>
+        <translation>Esci dall'applicazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="567"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="567" />
         <source>quit_app_question</source>
-        <extracomment>&quot;Quitter %1 ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Quitter %1 ?"</extracomment>
+        <translation>Uscire da %1?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="590"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="590" />
         <source>drawer_menu_add_account</source>
-        <extracomment>&quot;Ajouter un compte&quot;</extracomment>
+        <extracomment>"Ajouter un compte"</extracomment>
         <translation>Aggiungi un account</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="96"/>
+        <location filename="../../view/Page/Layout/Main/MainLayout.qml" line="96" />
         <source>contact_editor_dialog_abort_confirmation_save</source>
         <translation>Salvare</translation>
     </message>
@@ -4648,578 +4682,577 @@ Error</extracomment>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="41"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="41" />
         <source>information_popup_connexion_succeed_title</source>
-        <extracomment>&quot;Connexion réussie&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Connexion réussie"</extracomment>
+        <translation>Connessione riuscita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="43"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="43" />
         <source>information_popup_connexion_succeed_message</source>
-        <extracomment>&quot;Vous êtes connecté en mode %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vous êtes connecté en mode %1"</extracomment>
+        <translation>Sei connesso in modalità %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="45"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="45" />
         <source>interoperable</source>
         <extracomment>interopérable</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>interoperabile</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="74"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="74" />
         <source>call_transfer_successful_toast_title</source>
-        <extracomment>&quot;Appel transféré&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel transféré"</extracomment>
+        <translation>Chiamata trasferita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="76"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="76" />
         <source>call_transfer_successful_toast_message</source>
-        <extracomment>&quot;Votre correspondant a été transféré au contact sélectionné&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Votre correspondant a été transféré au contact sélectionné"</extracomment>
+        <translation>Il tuo interlocutore è stato trasferito al contatto selezionato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="132"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="132" />
         <source>information_popup_success_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Salvato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="134"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="134" />
         <source>information_popup_changes_saved</source>
-        <extracomment>&quot;Les changements ont été sauvegardés&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Les changements ont été sauvegardés"</extracomment>
+        <translation>Le modifiche sono state salvate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="207"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="207" />
         <source>oidc_connection_waiting_message</source>
-        <extracomment>&quot;Trying to connect to single sign on on web page ...&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Trying to connect to single sign on on web page ..."</extracomment>
+        <translation>Tentativo di connessione al single sign-on sulla pagina web…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="220"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="220" />
         <source>cancel</source>
         <extracomment>Cancel</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="257"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="257" />
         <source>captcha_validation_loading_message</source>
-        <extracomment>&quot;Veuillez valider le captcha sur la page web&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Veuillez valider le captcha sur la page web"</extracomment>
+        <translation>Convalida il captcha sulla pagina web</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="265"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="265" />
         <source>assistant_register_error_title</source>
-        <extracomment>&quot;Erreur lors de la création&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Erreur lors de la création"</extracomment>
+        <translation>Errore durante la creazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="285"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="285" />
         <source>assistant_register_success_title</source>
-        <extracomment>&quot;Compte créé&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Compte créé"</extracomment>
+        <translation>Account creato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="287"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="287" />
         <source>assistant_register_success_message</source>
-        <extracomment>&quot;Le compte a été créé. Vous pouvez maintenant vous connecter&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le compte a été créé. Vous pouvez maintenant vous connecter"</extracomment>
+        <translation>L'account è stato creato. Ora puoi accedere.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="292"/>
+        <location filename="../../view/Page/Window/Main/MainWindow.qml" line="292" />
         <source>assistant_register_error_code</source>
-        <extracomment>&quot;Erreur dans le code de validation&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Erreur dans le code de validation"</extracomment>
+        <translation>Errore nel codice di convalida</translation>
     </message>
 </context>
 <context>
     <name>ManageParticipants</name>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="29"/>
+        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="29" />
         <source>info_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="31"/>
+        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="31" />
         <source>info_popup_manage_participant_error_message</source>
         <extracomment>Error while setting participants !</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Errore durante l'impostazione dei partecipanti!</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="34"/>
+        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="34" />
         <source>info_popup_success_title</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="36"/>
+        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="36" />
         <source>info_popup_manage_participant_updated_message</source>
         <extracomment>Participants updated</extracomment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="59"/>
+        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="59" />
         <source>group_infos_manage_participants</source>
-        <translation type="unfinished"></translation>
+        <translation>Partecipanti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="68"/>
+        <location filename="../../view/Page/Layout/Chat/ManageParticipants.qml" line="68" />
         <source>apply_button_text</source>
         <extracomment>Apply</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Applica</translation>
     </message>
 </context>
 <context>
     <name>MeetingForm</name>
     <message>
-        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="43"/>
+        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="43" />
         <source>meeting_schedule_meeting_label</source>
-        <extracomment>&quot;Réunion&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Réunion"</extracomment>
+        <translation>Riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="55"/>
+        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="55" />
         <source>meeting_schedule_broadcast_label</source>
-        <extracomment>&quot;Webinar&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Webinar"</extracomment>
+        <translation>Webinar</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="78"/>
+        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="78" />
         <source>meeting_schedule_subject_hint</source>
-        <extracomment>&quot;Ajouter un titre&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter un titre"</extracomment>
+        <translation>Aggiungi un titolo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="124"/>
+        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="124" />
         <source>day_accessible_name</source>
         <extracomment>Day</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Giorno</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="153"/>
+        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="153" />
         <source>start_time_accessible_name</source>
         <extracomment>Start time</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Ora di inizio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="168"/>
+        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="168" />
         <source>end_time_accessible_name</source>
         <extracomment>End time</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Ora di fine</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="210"/>
+        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="210" />
         <source>timezone_accessible_name</source>
         <extracomment>Timezone</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Fuso orario</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="233"/>
+        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="233" />
         <source>meeting_schedule_description_hint</source>
-        <extracomment>&quot;Ajouter une description&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter une description"</extracomment>
+        <translation>Aggiungi una descrizione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="284"/>
+        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="284" />
         <source>meeting_schedule_add_participants_title</source>
-        <extracomment>&quot;Ajouter des participants&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter des participants"</extracomment>
+        <translation>Aggiungi partecipanti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="346"/>
+        <location filename="../../view/Page/Form/Meeting/MeetingForm.qml" line="346" />
         <source>meeting_schedule_send_invitations_title</source>
-        <extracomment>&quot;Envoyer une invitation aux participants&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Envoyer une invitation aux participants"</extracomment>
+        <translation>Invia un invito ai partecipanti</translation>
     </message>
 </context>
 <context>
     <name>MeetingListView</name>
     <message>
-        <location filename="../../view/Control/Display/Meeting/MeetingListView.qml" line="283"/>
+        <location filename="../../view/Control/Display/Meeting/MeetingListView.qml" line="283" />
         <source>meeting_info_cancelled</source>
-        <extracomment>&quot;Réunion annulée&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Réunion annulée"</extracomment>
+        <translation>Riunione annullata</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Meeting/MeetingListView.qml" line="307"/>
+        <location filename="../../view/Control/Display/Meeting/MeetingListView.qml" line="307" />
         <source>meetings_list_no_meeting_for_today</source>
-        <extracomment>&quot;Aucune réunion aujourd&apos;hui&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucune réunion aujourd'hui"</extracomment>
+        <translation>Nessuna riunione oggi</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Meeting/MeetingListView.qml" line="343"/>
+        <location filename="../../view/Control/Display/Meeting/MeetingListView.qml" line="343" />
         <source>meeting_info_delete</source>
-        <extracomment>&quot;Supprimer la réunion&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer la réunion"</extracomment>
+        <translation>Elimina riunione</translation>
     </message>
 </context>
 <context>
     <name>MeetingPage</name>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="18"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="18" />
         <source>meetings_add</source>
-        <extracomment>&quot;Créer une réunion&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Créer une réunion"</extracomment>
+        <translation>Crea riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="20"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="20" />
         <source>meetings_list_empty</source>
-        <extracomment>&quot;Aucune réunion&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucune réunion"</extracomment>
+        <translation>Nessuna riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="91"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="91" />
         <source>meeting_schedule_cancel_dialog_message</source>
-        <extracomment>&quot;Souhaitez-vous annuler et supprimer cette réunion ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Souhaitez-vous annuler et supprimer cette réunion ?"</extracomment>
+        <translation>Vuoi annullare ed eliminare questa riunione?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="93"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="93" />
         <source>meeting_schedule_delete_dialog_message</source>
         <extracomment>Souhaitez-vous supprimer cette réunion ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Vuoi eliminare questa riunione?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="106"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="106" />
         <source>meeting_schedule_cancel_and_delete_action</source>
-        <extracomment>&quot;Annuler et supprimer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Annuler et supprimer"</extracomment>
+        <translation>Annulla ed elimina</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="115"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="115" />
         <source>meeting_schedule_delete_only_action</source>
-        <extracomment>&quot;Supprimer seulement&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer seulement"</extracomment>
+        <translation>Elimina solo questa</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="117"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="117" />
         <source>meeting_schedule_delete_action</source>
-        <extracomment>&quot;Supprimer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer"</extracomment>
+        <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="126"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="126" />
         <source>back_action</source>
         <extracomment>Retour</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="171"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="171" />
         <source>meetings_list_title</source>
         <extracomment>Réunions</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Riunioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="211"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="211" />
         <source>meetings_search_hint</source>
-        <extracomment>&quot;Rechercher une réunion&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Rechercher une réunion"</extracomment>
+        <translation>Cerca una riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="228"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="228" />
         <source>list_filter_no_result_found</source>
-        <extracomment>&quot;Aucun résultat…&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucun résultat…"</extracomment>
+        <translation>Nessun risultato…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="230"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="230" />
         <source>meetings_empty_list</source>
-        <extracomment>&quot;Aucune réunion&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucune réunion"</extracomment>
+        <translation>Nessuna riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="307"/>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="368"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="307" />
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="368" />
         <source>meeting_schedule_title</source>
-        <extracomment>&quot;Nouvelle réunion&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nouvelle réunion"</extracomment>
+        <translation>Nuova riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="318"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="318" />
         <source>create</source>
-        <translation type="unfinished"></translation>
+        <translation>Crea</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="325"/>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="329"/>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="380"/>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="483"/>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="486"/>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="537"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="325" />
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="329" />
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="380" />
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="483" />
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="486" />
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="537" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="327"/>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="484"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="327" />
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="484" />
         <source>meeting_schedule_mandatory_field_not_filled_toast</source>
         <extracomment>Veuillez saisir un titre et sélectionner au moins un participant</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci un titolo e seleziona almeno un partecipante</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="331"/>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="487"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="331" />
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="487" />
         <source>meeting_schedule_duration_error_toast</source>
-        <extracomment>&quot;La fin de la conférence doit être plus récente que son début&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"La fin de la conférence doit être plus récente que son début"</extracomment>
+        <translation>La fine della conferenza deve essere successiva al suo inizio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="335"/>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="375"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="335" />
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="375" />
         <source>meeting_schedule_creation_in_progress</source>
-        <extracomment>&quot;Création de la réunion en cours …&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Création de la réunion en cours …"</extracomment>
+        <translation>Creazione della riunione in corso…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="370"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="370" />
         <source>meeting_info_created_toast</source>
-        <extracomment>&quot;Réunion planifiée avec succès&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Réunion planifiée avec succès"</extracomment>
+        <translation>Riunione pianificata con successo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="382"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="382" />
         <source>meeting_failed_to_schedule_toast</source>
-        <extracomment>&quot;Échec de création de la réunion !&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Échec de création de la réunion !"</extracomment>
+        <translation>Creazione della riunione non riuscita!</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="476"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="476" />
         <source>save</source>
         <translation>Salvare</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="526"/>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="765"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="526" />
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="765" />
         <source>saved</source>
-        <extracomment>&quot;Enregistré&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Enregistré"</extracomment>
+        <translation>Salvato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="528"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="528" />
         <source>meeting_info_updated_toast</source>
-        <extracomment>&quot;Réunion mise à jour&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Réunion mise à jour"</extracomment>
+        <translation>Riunione aggiornata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="533"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="533" />
         <source>meeting_schedule_edit_in_progress</source>
-        <extracomment>&quot;Modification de la réunion en cours…&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Modification de la réunion en cours…"</extracomment>
+        <translation>Modifica della riunione in corso…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="539"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="539" />
         <source>meeting_failed_to_edit_toast</source>
-        <extracomment>&quot;Échec de la modification de la réunion !&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Échec de la modification de la réunion !"</extracomment>
+        <translation>Modifica della riunione non riuscita!</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="587"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="587" />
         <source>meeting_schedule_add_participants_title</source>
-        <extracomment>&quot;Ajouter des participants&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter des participants"</extracomment>
+        <translation>Aggiungi partecipanti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="601"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="601" />
         <source>meeting_schedule_add_participants_apply</source>
-        <translation type="unfinished"></translation>
+        <translation>Applica</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="611"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="611" />
         <source>group_call_participant_selected</source>
-        <extracomment>&quot;%n participant(s) sélectionné(s)&quot;</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <extracomment>"%n participant(s) sélectionné(s)"</extracomment>
+        <translation>%1 partecipante selezionato<numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="704"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="704" />
         <source>meeting_info_delete</source>
-        <extracomment>&quot;Supprimer la réunion&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Supprimer la réunion"</extracomment>
+        <translation>Elimina riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="767"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="767" />
         <source>meeting_address_copied_to_clipboard_toast</source>
-        <extracomment>&quot;Adresse de la réunion copiée&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Adresse de la réunion copiée"</extracomment>
+        <translation>Indirizzo della riunione copiato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="803"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="803" />
         <source>meeting_schedule_timezone_title</source>
-        <extracomment>&quot;Fuseau horaire&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Fuseau horaire"</extracomment>
+        <translation>Fuso orario</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="923"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="923" />
         <source>meeting_info_organizer_label</source>
-        <extracomment>&quot;Organisateur&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Organisateur"</extracomment>
+        <translation>Organizzatore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="940"/>
+        <location filename="../../view/Page/Main/Meeting/MeetingPage.qml" line="940" />
         <source>meeting_info_join_title</source>
-        <extracomment>&quot;Rejoindre la réunion&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Rejoindre la réunion"</extracomment>
+        <translation>Partecipa alla riunione</translation>
     </message>
 </context>
 <context>
     <name>MeetingsSettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="16"/>
+        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="16" />
         <source>settings_meetings_display_title</source>
-        <extracomment>&quot;Affichage&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Affichage"</extracomment>
+        <translation>Visualizzazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="36"/>
-        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="58"/>
+        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="36" />
+        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="58" />
         <source>settings_meetings_default_layout_title</source>
-        <extracomment>&quot;Mode d’affichage par défaut&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Mode d’affichage par défaut"</extracomment>
+        <translation>Modalità di visualizzazione predefinita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="44"/>
+        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="44" />
         <source>settings_meetings_default_layout_subtitle</source>
-        <extracomment>&quot;Le mode d’affichage des participants en réunions&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le mode d’affichage des participants en réunions"</extracomment>
+        <translation>Come vengono mostrati i partecipanti nelle riunioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="63"/>
+        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="63" />
         <source>settings_meetings_show_past_meetings_title</source>
         <extracomment>Show past meetings</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Mostra riunioni passate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="65"/>
+        <location filename="../../view/Page/Layout/Settings/MeetingsSettingsLayout.qml" line="65" />
         <source>settings_meetings_show_past_meetings_subtitle</source>
         <extracomment>Display past meetings in the meeting list</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Mostra le riunioni passate nell'elenco delle riunioni</translation>
     </message>
 </context>
 <context>
     <name>MessageImdnStatusInfos</name>
     <message>
-        <location filename="../../view/Page/Layout/Chat/MessageImdnStatusInfos.qml" line="12"/>
+        <location filename="../../view/Page/Layout/Chat/MessageImdnStatusInfos.qml" line="12" />
         <source>message_details_status_title</source>
         <extracomment>Message status</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Stato del messaggio</translation>
     </message>
 </context>
 <context>
     <name>MessageReactionsInfos</name>
     <message>
-        <location filename="../../view/Page/Layout/Chat/MessageReactionsInfos.qml" line="13"/>
+        <location filename="../../view/Page/Layout/Chat/MessageReactionsInfos.qml" line="13" />
         <source>message_details_reactions_title</source>
         <extracomment>Reactions</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Reazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/MessageReactionsInfos.qml" line="56"/>
+        <location filename="../../view/Page/Layout/Chat/MessageReactionsInfos.qml" line="56" />
         <source>click_to_delete_reaction_info</source>
         <extracomment>Click to delete</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Clicca per eliminare</translation>
     </message>
 </context>
 <context>
     <name>MessageSharedFilesInfos</name>
     <message>
-        <location filename="../../view/Page/Layout/Chat/MessageSharedFilesInfos.qml" line="41"/>
+        <location filename="../../view/Page/Layout/Chat/MessageSharedFilesInfos.qml" line="41" />
         <source>no_shared_medias</source>
         <extracomment>No media</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nessun contenuto multimediale</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Chat/MessageSharedFilesInfos.qml" line="43"/>
+        <location filename="../../view/Page/Layout/Chat/MessageSharedFilesInfos.qml" line="43" />
         <source>no_shared_documents</source>
         <extracomment>No document</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nessun documento</translation>
     </message>
 </context>
 <context>
     <name>MultimediaSettings</name>
     <message>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="45"/>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="60"/>
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="45" />
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="60" />
         <source>multimedia_settings_ringer_title</source>
         <extracomment>Ringtone - Incoming calls</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Suoneria - Chiamate in arrivo</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="60"/>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="101"/>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="152"/>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="241"/>
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="60" />
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="101" />
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="152" />
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="241" />
         <source>choose_something_accessible_name</source>
         <extracomment>Choose %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Scegli %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="80"/>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="101"/>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="114"/>
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="80" />
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="101" />
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="114" />
         <source>multimedia_settings_speaker_title</source>
-        <extracomment>&quot;Haut-parleurs&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Haut-parleurs"</extracomment>
+        <translation>Altoparlanti</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="114"/>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="165"/>
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="114" />
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="165" />
         <source>device_volume_accessible_name</source>
         <extracomment>%1 volume</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Volume %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="131"/>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="152"/>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="165"/>
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="131" />
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="152" />
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="165" />
         <source>multimedia_settings_microphone_title</source>
-        <extracomment>&quot;Microphone&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Microphone"</extracomment>
+        <translation>Microfono</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="221"/>
-        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="241"/>
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="221" />
+        <location filename="../../view/Control/Form/Settings/MultimediaSettings.qml" line="241" />
         <source>multimedia_settings_camera_title</source>
-        <extracomment>&quot;Caméra&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Caméra"</extracomment>
+        <translation>Fotocamera</translation>
     </message>
 </context>
 <context>
     <name>NetworkSettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/NetworkSettingsLayout.qml" line="15"/>
+        <location filename="../../view/Page/Layout/Settings/NetworkSettingsLayout.qml" line="15" />
         <source>settings_network_title</source>
-        <extracomment>&quot;Réseau&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Réseau"</extracomment>
+        <translation>Rete</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/NetworkSettingsLayout.qml" line="32"/>
+        <location filename="../../view/Page/Layout/Settings/NetworkSettingsLayout.qml" line="32" />
         <source>settings_network_allow_ipv6</source>
-        <extracomment>&quot;Autoriser l&apos;IPv6&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Autoriser l'IPv6"</extracomment>
+        <translation>Abilita IPv6</translation>
     </message>
 </context>
 <context>
     <name>NewCallForm</name>
     <message>
-        <location filename="../../view/Page/Form/Call/NewCallForm.qml" line="24"/>
+        <location filename="../../view/Page/Form/Call/NewCallForm.qml" line="24" />
         <source>call_transfer_active_calls_label</source>
-        <extracomment>&quot;Appels en cours&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appels en cours"</extracomment>
+        <translation>Chiamata in corso</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Call/NewCallForm.qml" line="16"/>
+        <location filename="../../view/Page/Form/Call/NewCallForm.qml" line="16" />
         <source>call_start_group_call_title</source>
         <extracomment>Appel de groupe</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiamata di gruppo</translation>
     </message>
 </context>
 <context>
     <name>NewChatForm</name>
     <message>
-        <location filename="../../view/Page/Form/Chat/NewChatForm.qml" line="14"/>
+        <location filename="../../view/Page/Form/Chat/NewChatForm.qml" line="14" />
         <source>chat_start_group_chat_title</source>
         <extracomment>Nouveau groupe</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nuovo gruppo</translation>
     </message>
 </context>
 <context>
@@ -5248,310 +5281,310 @@ Error</extracomment>
 <context>
     <name>NotificationReceivedCall</name>
     <message>
-        <location filename="../../view/Control/Popup/Notification/NotificationReceivedCall.qml" line="95"/>
+        <location filename="../../view/Control/Popup/Notification/NotificationReceivedCall.qml" line="95" />
         <source>call_audio_incoming</source>
-        <extracomment>&quot;Appel entrant&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appel entrant"</extracomment>
+        <translation>Chiamata in arrivo</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Notification/NotificationReceivedCall.qml" line="118"/>
+        <location filename="../../view/Control/Popup/Notification/NotificationReceivedCall.qml" line="118" />
         <source>dialog_accept</source>
-        <extracomment>&quot;Accepter&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Accepter"</extracomment>
+        <translation>Accetta</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Notification/NotificationReceivedCall.qml" line="136"/>
+        <location filename="../../view/Control/Popup/Notification/NotificationReceivedCall.qml" line="136" />
         <source>dialog_deny</source>
-        <extracomment>&quot;Refuser</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Refuser</extracomment>
+        <translation>Rifiuta</translation>
     </message>
 </context>
 <context>
     <name>Notifier</name>
     <message>
-        <location filename="../../core/notifier/Notifier.cpp" line="348"/>
+        <location filename="../../core/notifier/Notifier.cpp" line="348" />
         <source>new_call_alert_accessible_name</source>
         <extracomment>New call from %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nuova chiamata da %1</translation>
     </message>
     <message>
-        <location filename="../../core/notifier/Notifier.cpp" line="403"/>
+        <location filename="../../core/notifier/Notifier.cpp" line="403" />
         <source>new_voice_message</source>
-        <extracomment>&apos;Voice message received!&apos; : message to warn the user in a notification for voice messages.</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>'Voice message received!' : message to warn the user in a notification for voice messages.</extracomment>
+        <translation>Messaggio vocale ricevuto!</translation>
     </message>
     <message>
-        <location filename="../../core/notifier/Notifier.cpp" line="404"/>
+        <location filename="../../core/notifier/Notifier.cpp" line="404" />
         <source>new_file_message</source>
-        <translation type="unfinished"></translation>
+        <translation>File ricevuto!</translation>
     </message>
     <message>
-        <location filename="../../core/notifier/Notifier.cpp" line="429"/>
+        <location filename="../../core/notifier/Notifier.cpp" line="429" />
         <source>new_chat_room_message</source>
-        <extracomment>&apos;New message received!&apos; Notification that warn the user of a new message.</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>'New message received!' Notification that warn the user of a new message.</extracomment>
+        <translation>Nuovo messaggio ricevuto!</translation>
     </message>
     <message>
-        <location filename="../../core/notifier/Notifier.cpp" line="432"/>
+        <location filename="../../core/notifier/Notifier.cpp" line="432" />
         <source>new_chat_room_messages</source>
-        <extracomment>&apos;New messages received!&apos; Notification that warn the user of new messages.</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>'New messages received!' Notification that warn the user of new messages.</extracomment>
+        <translation>Nuovi messaggi ricevuti!</translation>
     </message>
     <message>
-        <location filename="../../core/notifier/Notifier.cpp" line="460"/>
+        <location filename="../../core/notifier/Notifier.cpp" line="460" />
         <source>new_message_alert_accessible_name</source>
         <extracomment>New message on chatroom %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nuovo messaggio nella chat %1</translation>
     </message>
 </context>
 <context>
     <name>NumericPad</name>
     <message>
-        <location filename="../../view/Control/Input/NumericPad.qml" line="177"/>
+        <location filename="../../view/Control/Input/NumericPad.qml" line="177" />
         <source>numpad_longpress_accessible_name</source>
         <extracomment>%1 longpress %2</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>%1 pressione prolungata %2</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Input/NumericPad.qml" line="223"/>
+        <location filename="../../view/Control/Input/NumericPad.qml" line="223" />
         <source>call_accessible_name</source>
         <extracomment>Call</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiama</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Input/NumericPad.qml" line="245"/>
+        <location filename="../../view/Control/Input/NumericPad.qml" line="245" />
         <source>erase_accessible_name</source>
         <extracomment>Erase</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Cancella</translation>
     </message>
 </context>
 <context>
     <name>NumericPadPopup</name>
     <message>
-        <location filename="../../view/Control/Popup/NumericPadPopup.qml" line="60"/>
+        <location filename="../../view/Control/Popup/NumericPadPopup.qml" line="60" />
         <source>numeric_pad_accessible_name</source>
-        <extracomment>&quot;Numeric Pad&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Numeric Pad"</extracomment>
+        <translation>Tastierino numerico</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/NumericPadPopup.qml" line="71"/>
+        <location filename="../../view/Control/Popup/NumericPadPopup.qml" line="71" />
         <source>close_numeric_pad_accessible_name</source>
         <extracomment>Close numeric pad</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiudi tastierino numerico</translation>
     </message>
 </context>
 <context>
     <name>OIDCModel</name>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="56"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="56" />
         <source>OAuthHttpServerReplyHandler is not listening</source>
-        <translation type="unfinished"></translation>
+        <translation>OAuthHttpServerReplyHandler non è in ascolto</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="121"/>
-        <location filename="../../model/auth/OIDCModel.cpp" line="289"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="121" />
+        <location filename="../../model/auth/OIDCModel.cpp" line="289" />
         <source>oidc_authentication_timeout_message</source>
         <extracomment>Timeout: Not authenticated</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Timeout: non autenticato</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="140"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="140" />
         <source>oidc_authentication_granted_message</source>
         <extracomment>Authentication granted</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Autenticazione riuscita</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="147"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="147" />
         <source>oidc_authentication_not_authenticated_message</source>
         <extracomment>Not authenticated</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Non autenticato</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="153"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="153" />
         <source>oidc_authentication_refresh_message</source>
         <extracomment>Refreshing token</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Aggiornamento del token in corso</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="158"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="158" />
         <source>oidc_authentication_temporary_credentials_message</source>
         <extracomment>Temporary credentials received</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Credenziali temporanee ricevute</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="176"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="176" />
         <source>oidc_authentication_network_error</source>
         <extracomment>Network error</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Errore di rete</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="180"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="180" />
         <source>oidc_authentication_server_error</source>
         <extracomment>Server error</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Errore del server</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="184"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="184" />
         <source>oidc_authentication_token_not_found_error</source>
         <extracomment>OAuth token not found</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Token OAuth non trovato</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="188"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="188" />
         <source>oidc_authentication_token_secret_not_found_error</source>
         <extracomment>OAuth token secret not found</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Chiave segreta del token OAuth non trovata</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="192"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="192" />
         <source>oidc_authentication_callback_not_verified_error</source>
         <extracomment>OAuth callback not verified</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Callback OAuth non verificato</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="204"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="204" />
         <source>oidc_authentication_request_auth_message</source>
         <extracomment>Requesting authorization from browser</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Richiesta di autorizzazione dal browser in corso</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="239"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="239" />
         <source>oidc_authentication_no_token_found_error</source>
-        <translation type="unfinished"></translation>
+        <translation>Nessun token trovato</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="251"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="251" />
         <source>oidc_authentication_request_token_message</source>
         <extracomment>Requesting access token</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Richiesta del token di accesso in corso</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="256"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="256" />
         <source>oidc_authentication_refresh_token_message</source>
         <extracomment>Refreshing access token</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Aggiornamento del token di accesso in corso</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="261"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="261" />
         <source>oidc_authentication_request_authorization_message</source>
         <extracomment>Requesting authorization</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Richiesta di autorizzazione in corso</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="266"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="266" />
         <source>oidc_authentication_request_temporary_credentials_message</source>
         <extracomment>Requesting temporary credentials</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Richiesta di credenziali temporanee in corso</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="314"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="314" />
         <source>oidc_authentication_empty_reply_error</source>
         <extracomment>OIDC reply is empty !</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>La risposta OIDC è vuota!</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="324"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="324" />
         <source>oidc_authentication_no_auth_found_in_config_error</source>
         <extracomment>No authorization endpoint found in OpenID configuration</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nessun endpoint di autorizzazione trovato nella configurazione OpenID</translation>
     </message>
     <message>
-        <location filename="../../model/auth/OIDCModel.cpp" line="339"/>
+        <location filename="../../model/auth/OIDCModel.cpp" line="339" />
         <source>oidc_authentication_no_token_found_in_config_error</source>
         <extracomment>No token endpoint found in OpenID configuration</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nessun endpoint token trovato nella configurazione OpenID</translation>
     </message>
 </context>
 <context>
     <name>ParticipantListView</name>
     <message>
-        <location filename="../../view/Control/Display/Participant/ParticipantListView.qml" line="82"/>
+        <location filename="../../view/Control/Display/Participant/ParticipantListView.qml" line="82" />
         <source>meeting_participant_is_admin_label</source>
-        <extracomment>&quot;Admin&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Admin"</extracomment>
+        <translation>Amministratore</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Participant/ParticipantListView.qml" line="122"/>
+        <location filename="../../view/Control/Display/Participant/ParticipantListView.qml" line="122" />
         <source>meeting_add_participants_title</source>
-        <extracomment>&quot;Ajouter des participants&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ajouter des participants"</extracomment>
+        <translation>Aggiungi partecipanti</translation>
     </message>
 </context>
 <context>
     <name>PhoneNumberInput</name>
     <message>
-        <location filename="../../view/Control/Input/PhoneNumberInput.qml" line="62"/>
+        <location filename="../../view/Control/Input/PhoneNumberInput.qml" line="62" />
         <source>prefix_phone_number_accessible_name</source>
         <extracomment>%1 prefix</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>prefisso %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Input/PhoneNumberInput.qml" line="85"/>
+        <location filename="../../view/Control/Input/PhoneNumberInput.qml" line="85" />
         <source>number_phone_number_accessible_name</source>
         <extracomment>%1 number</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>numero %1</translation>
     </message>
 </context>
 <context>
     <name>PopupButton</name>
     <message>
-        <location filename="../../view/Control/Button/PopupButton.qml" line="18"/>
+        <location filename="../../view/Control/Button/PopupButton.qml" line="18" />
         <source>close_popup_panel_accessible_name</source>
-        <extracomment>&quot;Close %1 popup&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Close %1 popup"</extracomment>
+        <translation>Chiudi popup %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Button/PopupButton.qml" line="20"/>
+        <location filename="../../view/Control/Button/PopupButton.qml" line="20" />
         <source>open_popup_panel_accessible_name</source>
-        <extracomment>&quot;Open %1&quot; popup</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Open %1" popup</extracomment>
+        <translation>Apri popup %1</translation>
     </message>
 </context>
 <context>
     <name>Presence</name>
     <message>
-        <location filename="../../view/Control/Display/Contact/Presence.qml" line="30"/>
+        <location filename="../../view/Control/Display/Contact/Presence.qml" line="30" />
         <source>contact_presence_reset_status</source>
-        <translation type="unfinished"></translation>
+        <translation>Reimposta stato</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/Presence.qml" line="67"/>
+        <location filename="../../view/Control/Display/Contact/Presence.qml" line="67" />
         <source>contact_presence_button_set_custom_status</source>
-        <translation type="unfinished"></translation>
+        <translation>Imposta</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/Presence.qml" line="81"/>
+        <location filename="../../view/Control/Display/Contact/Presence.qml" line="81" />
         <source>contact_presence_button_edit_custom_status</source>
-        <translation type="unfinished"></translation>
+        <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/Presence.qml" line="89"/>
+        <location filename="../../view/Control/Display/Contact/Presence.qml" line="89" />
         <source>contact_presence_button_delete_custom_status</source>
-        <translation type="unfinished"></translation>
+        <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/Presence.qml" line="56"/>
+        <location filename="../../view/Control/Display/Contact/Presence.qml" line="56" />
         <source>contact_presence_custom_status</source>
-        <translation type="unfinished"></translation>
+        <translation>Stato personalizzato</translation>
     </message>
 </context>
 <context>
     <name>PresenceNoteLayout</name>
     <message>
-        <location filename="../../view/Control/Container/Contact/PresenceNoteLayout.qml" line="41"/>
+        <location filename="../../view/Control/Container/Contact/PresenceNoteLayout.qml" line="41" />
         <source>contact_presence_note_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Messaggio personalizzato</translation>
     </message>
 </context>
 <context>
     <name>PresenceSetCustomStatus</name>
     <message>
-        <location filename="../../view/Control/Display/Contact/PresenceSetCustomStatus.qml" line="17"/>
+        <location filename="../../view/Control/Display/Contact/PresenceSetCustomStatus.qml" line="17" />
         <source>contact_presence_button_set_custom_status_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Imposta un messaggio di stato personalizzato</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Contact/PresenceSetCustomStatus.qml" line="71"/>
+        <location filename="../../view/Control/Display/Contact/PresenceSetCustomStatus.qml" line="71" />
         <source>contact_presence_button_save_custom_status</source>
         <translation>Salvare</translation>
     </message>
@@ -5559,2621 +5592,2665 @@ Error</extracomment>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="63"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="63" />
         <source>media_encryption_dtls</source>
-        <translation type="unfinished"></translation>
+        <translation>DTLS</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="65"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="65" />
         <source>media_encryption_none</source>
-        <translation type="unfinished"></translation>
+        <translation>Nessuna</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="67"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="67" />
         <source>media_encryption_srtp</source>
-        <translation type="unfinished"></translation>
+        <translation>SRTP</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="70"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="70" />
         <source>media_encryption_post_quantum</source>
-        <extracomment>&quot;ZRTP - Post quantique&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"ZRTP - Post quantique"</extracomment>
+        <translation>ZRTP post-quantistico</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="126"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="126" />
         <source>message_state_idle</source>
-        <extracomment>&quot;idle&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"idle"</extracomment>
+        <translation>inattivo</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="129"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="129" />
         <source>message_state_in_progress</source>
-        <extracomment>&quot;delivery in progress&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"delivery in progress"</extracomment>
+        <translation>consegna in corso</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="132"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="132" />
         <source>message_state_delivered</source>
         <extracomment>sent</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>inviato</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="135"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="135" />
         <source>message_state_not_delivered</source>
         <extracomment>error</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>errore</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="138"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="138" />
         <source>message_state_file_transfer_error</source>
         <extracomment>cannot get file from server</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>impossibile ottenere il file dal server</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="141"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="141" />
         <source>message_state_file_transfer_done</source>
         <extracomment>file transfer has been completed successfully</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>trasferimento file completato con successo</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="144"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="144" />
         <source>message_state_delivered_to_user</source>
         <extracomment>received</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>ricevuto</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="147"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="147" />
         <source>message_state_displayed</source>
         <extracomment>read</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>letto</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="150"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="150" />
         <source>message_state_file_transfer__in_progress</source>
         <extracomment>file transfer in progress</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>trasferimento file in corso</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="153"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="153" />
         <source>message_state_pending_delivery</source>
         <extracomment>pending delivery</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>consegna in sospeso</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="156"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="156" />
         <source>message_state_file_transfer_cancelling</source>
         <extracomment>file transfer canceled</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>trasferimento file annullato</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="246"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="246" />
         <source>incoming</source>
-        <extracomment>&quot;Entrant&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Entrant"</extracomment>
+        <translation>In entrata</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="249"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="249" />
         <source>outgoing</source>
-        <extracomment>&quot;Sortant&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Sortant"</extracomment>
+        <translation>In uscita</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="275"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="275" />
         <source>conference_layout_active_speaker</source>
-        <extracomment>&quot;Participant actif&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Participant actif"</extracomment>
+        <translation>Partecipante attivo</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="277"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="277" />
         <source>conference_layout_grid</source>
-        <extracomment>&quot;Mosaïque&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Mosaïque"</extracomment>
+        <translation>Griglia</translation>
     </message>
     <message>
-        <location filename="../../tool/LinphoneEnums.cpp" line="279"/>
+        <location filename="../../tool/LinphoneEnums.cpp" line="279" />
         <source>conference_layout_audio_only</source>
-        <extracomment>&quot;Audio uniquement&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Audio uniquement"</extracomment>
+        <translation>Solo audio</translation>
     </message>
 </context>
 <context>
     <name>RecordListView</name>
     <message>
-        <location filename="../../view/Control/Display/Record/RecordListView.qml" line="265"/>
+        <location filename="../../view/Control/Display/Record/RecordListView.qml" line="265" />
         <source>meeting_info_cancelled</source>
-        <extracomment>&quot;Réunion annulée&quot;</extracomment>
-        <translation type="unfinished">Meeting canceled</translation>
+        <extracomment>"Réunion annulée"</extracomment>
+        <translation>Riunione annullata</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Record/RecordListView.qml" line="289"/>
+        <location filename="../../view/Control/Display/Record/RecordListView.qml" line="289" />
         <source>meetings_list_no_meeting_for_today</source>
-        <extracomment>&quot;Aucune réunion aujourd&apos;hui&quot;</extracomment>
-        <translation type="unfinished">No meeting for today</translation>
+        <extracomment>"Aucune réunion aujourd'hui"</extracomment>
+        <translation>Nessuna riunione oggi</translation>
     </message>
 </context>
 <context>
     <name>RecordPage</name>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="18"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="18" />
         <source>record_list_empty</source>
-        <extracomment>&quot;Aucun enregistrement&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucun enregistrement"</extracomment>
+        <translation>Nessuna registrazione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="62"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="62" />
         <source>record_list_title</source>
-        <extracomment>&quot;Records&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Records"</extracomment>
+        <translation>Registrazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="76"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="76" />
         <source>meetings_search_hint</source>
-        <extracomment>&quot;Rechercher une réunion&quot;</extracomment>
-        <translation type="unfinished">Find meeting</translation>
+        <extracomment>"Rechercher une réunion"</extracomment>
+        <translation>Cerca una riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="96"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="96" />
         <source>list_filter_no_result_found</source>
-        <extracomment>&quot;Aucun résultat…&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucun résultat…"</extracomment>
+        <translation>Nessun risultato…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="98"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="98" />
         <source>meetings_empty_list</source>
-        <extracomment>&quot;Aucun enregistrement&quot;</extracomment>
-        <translation type="unfinished">No meeting</translation>
+        <extracomment>"Aucun enregistrement"</extracomment>
+        <translation>Nessuna riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="168"/>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="229"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="168" />
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="229" />
         <source>meeting_schedule_title</source>
-        <extracomment>&quot;Nouvelle réunion&quot;</extracomment>
-        <translation type="unfinished">New meeting</translation>
+        <extracomment>"Nouvelle réunion"</extracomment>
+        <translation>Nuova riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="179"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="179" />
         <source>create</source>
-        <translation type="unfinished">Create</translation>
+        <translation>Crea</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="186"/>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="190"/>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="241"/>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="342"/>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="345"/>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="394"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="186" />
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="190" />
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="241" />
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="342" />
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="345" />
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="394" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="188"/>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="343"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="188" />
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="343" />
         <source>meeting_schedule_mandatory_field_not_filled_toast</source>
         <extracomment>Veuillez saisir un titre et sélectionner au moins un participant</extracomment>
-        <translation type="unfinished">Please fill the title and select at least one participant</translation>
+        <translation>Inserisci un titolo e seleziona almeno un partecipante</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="192"/>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="346"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="192" />
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="346" />
         <source>meeting_schedule_duration_error_toast</source>
-        <extracomment>&quot;La fin de la conférence doit être plus récente que son début&quot;</extracomment>
-        <translation type="unfinished">The end of the conference must be more recent than its beginning</translation>
+        <extracomment>"La fin de la conférence doit être plus récente que son début"</extracomment>
+        <translation>La fine della conferenza deve essere successiva al suo inizio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="196"/>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="236"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="196" />
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="236" />
         <source>meeting_schedule_creation_in_progress</source>
-        <extracomment>&quot;Création de la réunion en cours …&quot;</extracomment>
-        <translation type="unfinished">Creation in progress…</translation>
+        <extracomment>"Création de la réunion en cours …"</extracomment>
+        <translation>Creazione in corso…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="231"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="231" />
         <source>meeting_info_created_toast</source>
-        <extracomment>&quot;Réunion planifiée avec succès&quot;</extracomment>
-        <translation type="unfinished">Meeting successfully created</translation>
+        <extracomment>"Réunion planifiée avec succès"</extracomment>
+        <translation>Riunione creata con successo</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="243"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="243" />
         <source>meeting_failed_to_schedule_toast</source>
-        <extracomment>&quot;Échec de création de la réunion !&quot;</extracomment>
-        <translation type="unfinished">Failed to create meeting!</translation>
+        <extracomment>"Échec de création de la réunion !"</extracomment>
+        <translation>Creazione della riunione non riuscita!</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="335"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="335" />
         <source>save</source>
         <translation>Salvare</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="385"/>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="621"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="385" />
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="621" />
         <source>saved</source>
-        <extracomment>&quot;Enregistré&quot;</extracomment>
-        <translation type="unfinished">Saved</translation>
+        <extracomment>"Enregistré"</extracomment>
+        <translation>Salvato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="387"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="387" />
         <source>meeting_info_updated_toast</source>
-        <extracomment>&quot;Réunion mise à jour&quot;</extracomment>
-        <translation type="unfinished">Meeting updated</translation>
+        <extracomment>"Réunion mise à jour"</extracomment>
+        <translation>Riunione aggiornata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="392"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="392" />
         <source>meeting_schedule_edit_in_progress</source>
-        <extracomment>&quot;Modification de la réunion en cours…&quot;</extracomment>
-        <translation type="unfinished">Meeting update in progress…</translation>
+        <extracomment>"Modification de la réunion en cours…"</extracomment>
+        <translation>Aggiornamento riunione in corso…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="396"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="396" />
         <source>meeting_failed_to_edit_toast</source>
-        <extracomment>&quot;Échec de la modification de la réunion !&quot;</extracomment>
-        <translation type="unfinished">Failed to update meeting !</translation>
+        <extracomment>"Échec de la modification de la réunion !"</extracomment>
+        <translation>Aggiornamento della riunione non riuscito!</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="440"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="440" />
         <source>meeting_schedule_add_participants_title</source>
-        <extracomment>&quot;Ajouter des participants&quot;</extracomment>
-        <translation type="unfinished">Add participants</translation>
+        <extracomment>"Ajouter des participants"</extracomment>
+        <translation>Aggiungi partecipanti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="454"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="454" />
         <source>meeting_schedule_add_participants_apply</source>
-        <translation type="unfinished">Apply</translation>
+        <translation>Applica</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="464"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="464" />
         <source>group_call_participant_selected</source>
-        <extracomment>&quot;%n participant(s) sélectionné(s)&quot;</extracomment>
-        <translation type="unfinished">
-            <numerusform>%1 selected participant</numerusform>
+        <extracomment>"%n participant(s) sélectionné(s)"</extracomment>
+        <translation>%1 partecipante selezionato<numerusform>%1 selected participant</numerusform>
             <numerusform>%1 selected participants</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="552"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="552" />
         <source>meeting_info_delete</source>
-        <extracomment>&quot;Supprimer la réunion&quot;</extracomment>
-        <translation type="unfinished">Delete meeting</translation>
+        <extracomment>"Supprimer la réunion"</extracomment>
+        <translation>Elimina riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="623"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="623" />
         <source>meeting_address_copied_to_clipboard_toast</source>
-        <extracomment>&quot;Adresse de la réunion copiée&quot;</extracomment>
-        <translation type="unfinished">Meeting URI copied</translation>
+        <extracomment>"Adresse de la réunion copiée"</extracomment>
+        <translation>URI della riunione copiato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="659"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="659" />
         <source>meeting_schedule_timezone_title</source>
-        <extracomment>&quot;Fuseau horaire&quot;</extracomment>
-        <translation type="unfinished">Timezone</translation>
+        <extracomment>"Fuseau horaire"</extracomment>
+        <translation>Fuso orario</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="761"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="761" />
         <source>meeting_info_organizer_label</source>
-        <extracomment>&quot;Organisateur&quot;</extracomment>
-        <translation type="unfinished">Organizer</translation>
+        <extracomment>"Organisateur"</extracomment>
+        <translation>Organizzatore</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="780"/>
+        <location filename="../../view/Page/Main/Record/RecordPage.qml" line="780" />
         <source>meeting_info_join_title</source>
-        <extracomment>&quot;Rejoindre la réunion&quot;</extracomment>
-        <translation type="unfinished">Join meeting</translation>
+        <extracomment>"Rejoindre la réunion"</extracomment>
+        <translation>Partecipa alla riunione</translation>
     </message>
 </context>
 <context>
     <name>RegisterCheckingPage</name>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="45"/>
+        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="45" />
         <source>email</source>
-        <extracomment>&quot;email&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"email"</extracomment>
+        <translation>email</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="47"/>
+        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="47" />
         <source>phone_number</source>
-        <extracomment>&quot;numéro de téléphone&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"numéro de téléphone"</extracomment>
+        <translation>numero di telefono</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="49"/>
+        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="49" />
         <source>confirm_register_title</source>
-        <extracomment>&quot;Inscription | Confirmer votre %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Inscription | Confirmer votre %1"</extracomment>
+        <translation>Registrazione | Conferma il tuo %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="79"/>
+        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="79" />
         <source>assistant_account_creation_confirmation_explanation</source>
         <extracomment>Nous vous avons envoyé un code de vérification sur votre %1 %2&lt;br&gt; Merci de le saisir ci-dessous</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Ti abbiamo inviato un codice di verifica al tuo %1 %2 
+ Inseriscilo qui sotto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="156"/>
+        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="156" />
         <source>assistant_account_creation_confirmation_did_not_receive_code</source>
-        <extracomment>&quot;Vous n&apos;avez pas reçu le code ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vous n'avez pas reçu le code ?"</extracomment>
+        <translation>Non hai ricevuto il codice?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="164"/>
+        <location filename="../../view/Page/Form/Register/RegisterCheckingPage.qml" line="164" />
         <source>assistant_account_creation_confirmation_resend_code</source>
-        <extracomment>&quot;Renvoyer un code&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Renvoyer un code"</extracomment>
+        <translation>Invia di nuovo il codice</translation>
     </message>
 </context>
 <context>
     <name>RegisterPage</name>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="46"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="46" />
         <source>return_accessible_name</source>
         <extracomment>Return</extracomment>
         <translation>indietro</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="58"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="58" />
         <source>assistant_account_register</source>
-        <extracomment>&quot;Inscription</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Inscription</extracomment>
+        <translation>Registrati</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="77"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="77" />
         <source>assistant_already_have_an_account</source>
-        <translation type="unfinished"></translation>
+        <translation>Hai già un account?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="85"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="85" />
         <source>assistant_account_login</source>
-        <translation type="unfinished"></translation>
+        <translation>Accedi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="107"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="107" />
         <source>assistant_account_register_with_phone_number</source>
-        <translation type="unfinished"></translation>
+        <translation>Registrati con un numero di telefono</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="109"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="109" />
         <source>assistant_account_register_with_email</source>
-        <translation type="unfinished"></translation>
+        <translation>Registrati con l'email</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="138"/>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="147"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="138" />
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="147" />
         <source>username</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome utente</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="147"/>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="182"/>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="196"/>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="220"/>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="236"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="147" />
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="182" />
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="196" />
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="220" />
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="236" />
         <source>mandatory_field_accessible_name</source>
-        <extracomment>&quot;%1 mandatory&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"%1 mandatory"</extracomment>
+        <translation>%1 obbligatorio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="158"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="158" />
         <source>domain</source>
-        <translation type="unfinished"></translation>
+        <translation>Dominio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="176"/>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="179"/>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="182"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="176" />
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="179" />
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="182" />
         <source>phone_number</source>
-        <extracomment>&quot;Numéro de téléphone&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Numéro de téléphone"</extracomment>
+        <translation>Numero di telefono</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="188"/>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="196"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="188" />
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="196" />
         <source>email</source>
-        <translation type="unfinished"></translation>
+        <translation>Email</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="210"/>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="220"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="210" />
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="220" />
         <source>password</source>
-        <translation type="unfinished"></translation>
+        <translation>Password</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="227"/>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="236"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="227" />
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="236" />
         <source>assistant_account_register_password_confirmation</source>
-        <extracomment>&quot;Confirmation mot de passe&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Confirmation mot de passe"</extracomment>
+        <translation>Conferma password</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="272"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="272" />
         <source>assistant_dialog_cgu_and_privacy_policy_message</source>
-        <extracomment>&quot;J&apos;accepte les %1 et la %2&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"J'accepte les %1 et la %2"</extracomment>
+        <translation>Accetto i %1 e la %2</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="274"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="274" />
         <source>assistant_dialog_general_terms_label</source>
-        <extracomment>&quot;conditions d&apos;utilisation&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"conditions d'utilisation"</extracomment>
+        <translation>condizioni d'uso</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="276"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="276" />
         <source>assistant_dialog_privacy_policy_label</source>
-        <extracomment>&quot;politique de confidentialité&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"politique de confidentialité"</extracomment>
+        <translation>informativa sulla privacy</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="311"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="311" />
         <source>assistant_account_create</source>
-        <extracomment>&quot;Créer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Créer"</extracomment>
+        <translation>Crea</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="316"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="316" />
         <source>assistant_account_create_missing_username_error</source>
-        <extracomment>&quot;Veuillez entrer un nom d&apos;utilisateur&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Veuillez entrer un nom d'utilisateur"</extracomment>
+        <translation>Inserisci un nome utente</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="320"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="320" />
         <source>assistant_account_create_missing_password_error</source>
-        <extracomment>&quot;Veuillez entrer un mot de passe&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Veuillez entrer un mot de passe"</extracomment>
+        <translation>Inserisci una password</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="324"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="324" />
         <source>assistant_account_create_confirm_password_error</source>
-        <extracomment>&quot;Les mots de passe sont différents&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Les mots de passe sont différents"</extracomment>
+        <translation>Le password non coincidono</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="328"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="328" />
         <source>assistant_account_create_missing_number_error</source>
-        <extracomment>&quot;Veuillez entrer un numéro de téléphone&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Veuillez entrer un numéro de téléphone"</extracomment>
+        <translation>Inserisci un numero di telefono</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="332"/>
+        <location filename="../../view/Page/Form/Register/RegisterPage.qml" line="332" />
         <source>assistant_account_create_missing_email_error</source>
-        <extracomment>&quot;Veuillez entrer un email&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Veuillez entrer un email"</extracomment>
+        <translation>Inserisci un'email</translation>
     </message>
 </context>
 <context>
     <name>SIPLoginPage</name>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="33"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="33" />
         <source>return_accessible_name</source>
         <extracomment>Return</extracomment>
         <translation>indietro</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="44"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="44" />
         <source>assistant_login_third_party_sip_account_title</source>
         <extracomment>Compte SIP tiers</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Account SIP di terze parti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="62"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="62" />
         <source>assistant_no_account_yet</source>
         <extracomment>Pas encore de compte ?</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Non hai ancora un account?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="71"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="71" />
         <source>assistant_account_register</source>
-        <extracomment>S&apos;inscrire</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>S'inscrire</extracomment>
+        <translation>Registrati</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="110"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="110" />
         <source>Certaines fonctionnalités telles que les conversations de groupe, les vidéo-conférences, etc… nécessitent un compte %1.
 
 Ces fonctionnalités seront masquées si vous utilisez un compte SIP tiers.
 
 Pour les activer dans un projet commercial, merci de nous contacter.</source>
-        <translation type="unfinished"></translation>
+        <translation>Alcune funzionalità come le chat di gruppo, le videoconferenze, ecc. richiedono un account %1.
+
+Queste funzionalità saranno nascoste se utilizzi un account SIP di terze parti.
+
+Per attivarle in un progetto commerciale, contattaci.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="133"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="133" />
         <source>assistant_third_party_sip_account_create_linphone_account</source>
-        <extracomment>&quot;Créer un compte linphone&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Créer un compte linphone"</extracomment>
+        <translation>Crea un account linphone</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="145"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="145" />
         <source>assistant_third_party_sip_account_warning_ok</source>
-        <extracomment>&quot;Je comprends&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Je comprends"</extracomment>
+        <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="190"/>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="200"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="190" />
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="200" />
         <source>username</source>
-        <extracomment>&quot;Nom d&apos;utilisateur&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Nom d'utilisateur"</extracomment>
+        <translation>Nome utente</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="200"/>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="237"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="200" />
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="237" />
         <source>mandatory_field_accessible_name</source>
-        <extracomment>&quot;%1 mandatory&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"%1 mandatory"</extracomment>
+        <translation>%1 obbligatorio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="205"/>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="216"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="205" />
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="216" />
         <source>password</source>
-        <translation type="unfinished"></translation>
+        <translation>Password</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="222"/>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="237"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="222" />
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="237" />
         <source>sip_address_domain</source>
-        <extracomment>&quot;Domaine&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Domaine"</extracomment>
+        <translation>Dominio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="224"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="224" />
         <source>sip_address_domain_tooltip</source>
-        <extracomment>&quot;Domaine de votre identité SIP (ex: sip.example.com)&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Domaine de votre identité SIP (ex: sip.example.com)"</extracomment>
+        <translation>Dominio della tua identità SIP (es: sip.example.com)</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="248"/>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="255"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="248" />
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="255" />
         <source>sip_address_display_name</source>
-        <extracomment>Nom d&apos;affichage</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>Nom d'affichage</extracomment>
+        <translation>Nome visualizzato</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="260"/>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="279"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="260" />
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="279" />
         <source>transport</source>
-        <extracomment>&quot;Transport&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Transport"</extracomment>
+        <translation>Trasporto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="301"/>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="306"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="301" />
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="306" />
         <source>assistant_account_login</source>
-        <translation type="unfinished"></translation>
+        <translation>Accedi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="357"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="357" />
         <source>assistant_account_login_missing_username</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci un nome utente</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="359"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="359" />
         <source>assistant_account_login_missing_password</source>
-        <translation type="unfinished"></translation>
+        <translation>Inserisci una password</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="362"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="362" />
         <source>assistant_account_login_missing_domain</source>
-        <extracomment>&quot;Veuillez saisir un nom de domaine</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Veuillez saisir un nom de domaine</extracomment>
+        <translation>Inserisci un nome di dominio</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="385"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="385" />
         <source>login_advanced_parameters_label</source>
         <extracomment>Advanced parameters</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Parametri avanzati</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="419"/>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="426"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="419" />
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="426" />
         <source>login_proxy_server_url</source>
-        <extracomment>&quot;Outbound SIP Proxy URI&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Outbound SIP Proxy URI"</extracomment>
+        <translation>URI proxy SIP in uscita</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="421"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="421" />
         <source>login_proxy_server_url_tooltip</source>
-        <extracomment>&quot;If this field is filled, the outbound proxy will be enabled automatically. Leave it empty to disable it.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"If this field is filled, the outbound proxy will be enabled automatically. Leave it empty to disable it."</extracomment>
+        <translation>Se questo campo è compilato, il proxy in uscita verrà attivato automaticamente. Lascialo vuoto per disattivarlo.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="406"/>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="411"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="406" />
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="411" />
         <source>login_registrar_uri</source>
-        <extracomment>&quot;Registrar URI&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Registrar URI"</extracomment>
+        <translation>URI del registrar</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="393"/>
-        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="398"/>
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="393" />
+        <location filename="../../view/Page/Form/Login/SIPLoginPage.qml" line="398" />
         <source>login_id</source>
-        <extracomment>&quot;Authentication ID (if different)&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Authentication ID (if different)"</extracomment>
+        <translation>ID di autenticazione (se diverso)</translation>
     </message>
 </context>
 <context>
     <name>ScreencastSettings</name>
     <message>
-        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="24"/>
+        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="24" />
         <source>screencast_settings_choose_window_text</source>
-        <extracomment>&quot;Veuillez choisir l’écran ou la fenêtre que vous souihaitez partager au autres participants&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Veuillez choisir l’écran ou la fenêtre que vous souihaitez partager au autres participants"</extracomment>
+        <translation>Scegli lo schermo o la finestra che vuoi condividere con gli altri partecipanti.</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="34"/>
+        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="34" />
         <source>screencast_settings_all_screen_label</source>
-        <extracomment>&quot;Ecran entier&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ecran entier"</extracomment>
+        <translation>Schermo intero</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="36"/>
+        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="36" />
         <source>screencast_settings_one_window_label</source>
-        <extracomment>&quot;Fenêtre&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Fenêtre"</extracomment>
+        <translation>Finestra</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="94"/>
+        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="94" />
         <source>screencast_settings_screen</source>
-        <extracomment>&quot;Ecran %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ecran %1"</extracomment>
+        <translation>Schermo %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="179"/>
+        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="179" />
         <source>stop</source>
-        <extracomment>&quot;Stop</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Stop</extracomment>
+        <translation>Interrompi</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="181"/>
+        <location filename="../../view/Control/Form/Settings/ScreencastSettings.qml" line="181" />
         <source>share</source>
-        <extracomment>&quot;Partager&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Partager"</extracomment>
+        <translation>Condividi</translation>
     </message>
 </context>
 <context>
     <name>SearchBar</name>
     <message>
-        <location filename="../../view/Control/Input/SearchBar.qml" line="131"/>
+        <location filename="../../view/Control/Input/SearchBar.qml" line="131" />
         <source>open_dialer_acccessibility_label</source>
-        <extracomment>&quot;Open dialer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Open dialer"</extracomment>
+        <translation>Apri tastierino</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Input/SearchBar.qml" line="151"/>
+        <location filename="../../view/Control/Input/SearchBar.qml" line="151" />
         <source>clear_text_input_acccessibility_label</source>
-        <extracomment>&quot;Clear text input&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Clear text input"</extracomment>
+        <translation>Cancella testo</translation>
     </message>
 </context>
 <context>
     <name>SecurityModePage</name>
     <message>
-        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="23"/>
+        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="23" />
         <source>manage_account_choose_mode_title</source>
-        <extracomment>&quot;Choisir votre mode&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Choisir votre mode"</extracomment>
+        <translation>Scegli la tua modalità</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="31"/>
+        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="31" />
         <source>manage_account_choose_mode_message</source>
-        <extracomment>&quot;Vous pourrez changer de mode plus tard.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vous pourrez changer de mode plus tard."</extracomment>
+        <translation>Potrai cambiare modalità in seguito.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="51"/>
+        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="51" />
         <source>manage_account_e2e_encrypted_mode_default_title</source>
-        <extracomment>&quot;Chiffrement de bout en bout&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Chiffrement de bout en bout"</extracomment>
+        <translation>Crittografia end-to-end</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="53"/>
+        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="53" />
         <source>manage_account_e2e_encrypted_mode_default_summary</source>
-        <extracomment>&quot;Ce mode vous garanti la confidentialité de tous vos échanges. Notre technologie de chiffrement de bout en bout assure un niveau de sécurité maximal pour tous vos échanges.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ce mode vous garanti la confidentialité de tous vos échanges. Notre technologie de chiffrement de bout en bout assure un niveau de sécurité maximal pour tous vos échanges."</extracomment>
+        <translation>Questa modalità garantisce la riservatezza di tutte le tue comunicazioni. La nostra tecnologia di crittografia end-to-end assicura il massimo livello di sicurezza per tutti i tuoi scambi.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="55"/>
+        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="55" />
         <source>manage_account_e2e_encrypted_mode_interoperable_title</source>
-        <extracomment>&quot;Interoperable&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Interoperable"</extracomment>
+        <translation>Interoperabile</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="57"/>
+        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="57" />
         <source>manage_account_e2e_encrypted_mode_interoperable_summary</source>
-        <extracomment>&quot;Ce mode vous permet de profiter de toute les fonctionnalités de Linphone, toute en restant interopérable avec n’importe qu’elle autre service SIP.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Ce mode vous permet de profiter de toute les fonctionnalités de Linphone, toute en restant interopérable avec n’importe qu’elle autre service SIP."</extracomment>
+        <translation>Questa modalità ti permette di usufruire di tutte le funzionalità di Linphone, restando comunque interoperabile con qualsiasi altro servizio SIP.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="77"/>
+        <location filename="../../view/Page/Form/Security/SecurityModePage.qml" line="77" />
         <source>dialog_continue</source>
-        <extracomment>&quot;Continuer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Continuer"</extracomment>
+        <translation>Continua</translation>
     </message>
 </context>
 <context>
     <name>SecuritySettingsLayout</name>
     <message>
-        <location filename="../../view/Page/Layout/Settings/SecuritySettingsLayout.qml" line="29"/>
+        <location filename="../../view/Page/Layout/Settings/SecuritySettingsLayout.qml" line="29" />
         <source>settings_security_enable_vfs_title</source>
-        <extracomment>&quot;Chiffrer tous les fichiers&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Chiffrer tous les fichiers"</extracomment>
+        <translation>Crittografa tutti i file</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Layout/Settings/SecuritySettingsLayout.qml" line="31"/>
+        <location filename="../../view/Page/Layout/Settings/SecuritySettingsLayout.qml" line="31" />
         <source>settings_security_enable_vfs_subtitle</source>
-        <extracomment>&quot;Attention, vous ne pourrez pas revenir en arrière !&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Attention, vous ne pourrez pas revenir en arrière !"</extracomment>
+        <translation>Attenzione: una volta attivata non potrà essere disattivata!</translation>
     </message>
 </context>
 <context>
     <name>SelectedChatView</name>
     <message>
-        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="59"/>
+        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="59" />
         <source>chat_view_group_call_toast_message</source>
-        <translation type="unfinished"></translation>
+        <translation>Avviare una chiamata di gruppo?</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="486"/>
+        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="486" />
         <source>reply_to_label</source>
         <extracomment>Reply to %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Rispondi a %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="487"/>
+        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="487" />
         <source>conversation_editing_message_title</source>
-        <translation type="unfinished"></translation>
+        <translation>Messaggio in fase di modifica</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="706"/>
+        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="706" />
         <source>shared_medias_title</source>
         <extracomment>Shared medias</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Media condivisi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="708"/>
+        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="708" />
         <source>shared_documents_title</source>
         <extracomment>Shared documents</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Documenti condivisi</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="737"/>
+        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="737" />
         <source>forward_to_title</source>
         <extracomment>Forward to…</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Inoltra a…</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="771"/>
+        <location filename="../../view/Page/Form/Chat/SelectedChatView.qml" line="771" />
         <source>conversations_title</source>
         <extracomment>Conversations</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Conversazioni</translation>
     </message>
 </context>
 <context>
     <name>SettingsMenuItem</name>
     <message>
-        <location filename="../../view/Control/Display/Settings/SettingsMenuItem.qml" line="22"/>
+        <location filename="../../view/Control/Display/Settings/SettingsMenuItem.qml" line="22" />
         <source>setting_tab_accessible_name</source>
         <extracomment>%1 settings</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impostazioni %1</translation>
     </message>
 </context>
 <context>
     <name>SettingsPage</name>
     <message>
-        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="12"/>
+        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="33" />
+        <source>settings_pbx_title</source>
+        <extracomment>"Intégration PBX"</extracomment>
+        <translation>Integrazione PBX</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="12" />
         <source>settings_title</source>
-        <extracomment>&quot;Paramètres&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Paramètres"</extracomment>
+        <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="15"/>
+        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="15" />
         <source>settings_calls_title</source>
-        <extracomment>&quot;Appels&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Appels"</extracomment>
+        <translation>Chiamate</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="17"/>
+        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="17" />
         <source>settings_call_forward</source>
-        <extracomment>&quot;Transfert d&apos;appel&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Transfert d'appel"</extracomment>
+        <translation>Deviazione di chiamata</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="19"/>
+        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="19" />
         <source>settings_conversations_title</source>
-        <extracomment>&quot;Conversations&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Conversations"</extracomment>
+        <translation>Conversazioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="21"/>
+        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="21" />
         <source>settings_contacts_title</source>
-        <extracomment>&quot;Contacts&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Contacts"</extracomment>
+        <translation>Contatti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="23"/>
+        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="23" />
         <source>settings_meetings_title</source>
-        <extracomment>&quot;Réunions&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Réunions"</extracomment>
+        <translation>Riunioni</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="29"/>
+        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="29" />
         <source>settings_network_title</source>
-        <extracomment>&quot;Affichage&quot; &quot;Security&quot; &quot;Réseau&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Affichage" "Security" "Réseau"</extracomment>
+        <translation>Rete</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="31"/>
+        <location filename="../../view/Page/Form/Settings/SettingsPage.qml" line="31" />
         <source>settings_advanced_title</source>
-        <extracomment>&quot;Paramètres avancés&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Paramètres avancés"</extracomment>
+        <translation>Parametri avanzati</translation>
     </message>
 </context>
 <context>
     <name>Sticker</name>
     <message>
-        <location filename="../../view/Control/Display/Sticker.qml" line="136"/>
+        <location filename="../../view/Control/Display/Sticker.qml" line="136" />
         <source>conference_participant_joining_text</source>
-        <extracomment>&quot;rejoint…&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"rejoint…"</extracomment>
+        <translation>in ingresso…</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Display/Sticker.qml" line="162"/>
+        <location filename="../../view/Control/Display/Sticker.qml" line="162" />
         <source>conference_participant_paused_text</source>
-        <extracomment>&quot;En pause&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"En pause"</extracomment>
+        <translation>In pausa</translation>
     </message>
 </context>
 <context>
     <name>TextField</name>
     <message>
-        <location filename="../../view/Control/Input/TextField.qml" line="211"/>
+        <location filename="../../view/Control/Input/TextField.qml" line="211" />
         <source>show_accessible_name</source>
         <extracomment>Show %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Mostra %1</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Input/TextField.qml" line="230"/>
+        <location filename="../../view/Control/Input/TextField.qml" line="230" />
         <source>textfield_custom_button_accessible_name</source>
         <extracomment>%1 button of %2</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Pulsante %1 di %2</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Input/TextField.qml" line="209"/>
+        <location filename="../../view/Control/Input/TextField.qml" line="209" />
         <source>hide_accessible_name</source>
         <extracomment>Hide %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Nascondi %1</translation>
     </message>
 </context>
 <context>
     <name>ToolModel</name>
     <message>
-        <location filename="../../model/tool/ToolModel.cpp" line="331"/>
+        <location filename="../../model/tool/ToolModel.cpp" line="331" />
         <source>call_error_uninterpretable_sip_address</source>
-        <extracomment>&quot;The calling address is not an interpretable SIP address : %1</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"The calling address is not an interpretable SIP address : %1</extracomment>
+        <translation>L'indirizzo chiamante non è un indirizzo SIP interpretabile: %1</translation>
     </message>
     <message>
-        <location filename="../../model/tool/ToolModel.cpp" line="406"/>
+        <location filename="../../model/tool/ToolModel.cpp" line="406" />
         <source>group_call_error_no_account</source>
-        <translation type="unfinished"></translation>
+        <translation>Nessun account predefinito trovato, impossibile creare la chiamata di gruppo</translation>
     </message>
     <message>
-        <location filename="../../model/tool/ToolModel.cpp" line="436"/>
+        <location filename="../../model/tool/ToolModel.cpp" line="436" />
         <source>group_call_error_participants_invite</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile invitare i partecipanti alla chiamata di gruppo</translation>
     </message>
     <message>
-        <location filename="../../model/tool/ToolModel.cpp" line="440"/>
+        <location filename="../../model/tool/ToolModel.cpp" line="440" />
         <source>group_call_error_creation</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile creare la chiamata di gruppo</translation>
     </message>
     <message>
-        <location filename="../../model/tool/ToolModel.cpp" line="540"/>
+        <location filename="../../model/tool/ToolModel.cpp" line="540" />
         <source>voice_recording_duration</source>
-        <extracomment>&quot;Voice recording (%1)&quot; : %1 is the duration formated in mm:ss</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Voice recording (%1)" : %1 is the duration formated in mm:ss</extracomment>
+        <translation>Registrazione vocale (%1)</translation>
     </message>
     <message>
-        <location filename="../../model/tool/ToolModel.cpp" line="623"/>
+        <location filename="../../model/tool/ToolModel.cpp" line="623" />
         <source>unknown_audio_device_name</source>
-        <extracomment>&quot;Unknown device&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Unknown device"</extracomment>
+        <translation>Dispositivo sconosciuto</translation>
     </message>
     <message>
-        <location filename="../../model/tool/ToolModel.cpp" line="548"/>
+        <location filename="../../model/tool/ToolModel.cpp" line="548" />
         <source>conference_invitation</source>
-        <translation type="unfinished"></translation>
+        <translation>Invito alla riunione</translation>
     </message>
     <message>
-        <location filename="../../model/tool/ToolModel.cpp" line="552"/>
+        <location filename="../../model/tool/ToolModel.cpp" line="552" />
         <source>conference_invitation_cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Annullamento della riunione</translation>
     </message>
     <message>
-        <location filename="../../model/tool/ToolModel.cpp" line="550"/>
+        <location filename="../../model/tool/ToolModel.cpp" line="550" />
         <source>conference_invitation_updated</source>
-        <translation type="unfinished"></translation>
+        <translation>Modifica della riunione</translation>
     </message>
     <message>
-        <location filename="../../model/tool/ToolModel.cpp" line="563"/>
+        <location filename="../../model/tool/ToolModel.cpp" line="563" />
         <source>conversation_message_content_deleted_label</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;lt;i&amp;gt;Questo messaggio è stato eliminato&amp;lt;/i&amp;gt;</translation>
     </message>
     <message>
-        <location filename="../../model/tool/ToolModel.cpp" line="562"/>
+        <location filename="../../model/tool/ToolModel.cpp" line="562" />
         <source>conversation_message_content_deleted_by_us_label</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;lt;i&amp;gt;Hai eliminato questo messaggio&amp;lt;/i&amp;gt;</translation>
     </message>
 </context>
 <context>
     <name>Utils</name>
     <message numerus="yes">
-        <location filename="../../tool/Utils.cpp" line="2296"/>
+        <location filename="../../tool/Utils.cpp" line="2296" />
         <source>nSeconds</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            %1 secondo
+            %1 secondi
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../tool/Utils.cpp" line="2291"/>
+        <location filename="../../tool/Utils.cpp" line="2291" />
         <source>nMinute</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            %1 minuto
+            %1 minuti
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2061"/>
+        <location filename="../../tool/Utils.cpp" line="2061" />
         <source>chat_message_forward_error</source>
         <extracomment>Cannot forward an invalid message</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile inoltrare un messaggio non valido</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2067"/>
+        <location filename="../../tool/Utils.cpp" line="2067" />
         <source>info_popup_forward_message_error</source>
         <extracomment>Could not forward message : %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile inoltrare il messaggio: %1</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2082"/>
+        <location filename="../../tool/Utils.cpp" line="2082" />
         <source>info_popup_send_forward_message_error_message</source>
         <extracomment>Failed to create forward message</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile creare il messaggio da inoltrare</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2093"/>
+        <location filename="../../tool/Utils.cpp" line="2093" />
         <source>chat_message_reply_error</source>
         <extracomment>Cannot reply to invalid message</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile rispondere a un messaggio non valido</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2137"/>
+        <location filename="../../tool/Utils.cpp" line="2137" />
         <source>chat_message_edit_error</source>
         <extracomment>Cannot edit to invalid message</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile modificare un messaggio non valido</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2099"/>
+        <location filename="../../tool/Utils.cpp" line="2099" />
         <source>info_popup_reply_message_error</source>
         <extracomment>Could not send reply message : %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile inviare la risposta: %1</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2143"/>
+        <location filename="../../tool/Utils.cpp" line="2143" />
         <source>info_popup_edited_message_error</source>
         <extracomment>Could not send edited message : %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile inviare il messaggio modificato: %1</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2126"/>
+        <location filename="../../tool/Utils.cpp" line="2126" />
         <source>info_popup_send_reply_message_error_message</source>
         <extracomment>Failed to create reply message</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile creare il messaggio di risposta</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2170"/>
+        <location filename="../../tool/Utils.cpp" line="2170" />
         <source>info_popup_send_edited_message_error_message</source>
         <extracomment>Failed to create edited message</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile creare il messaggio modificato</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../tool/Utils.cpp" line="2292"/>
+        <location filename="../../tool/Utils.cpp" line="2292" />
         <source>nHour</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            %1 ora
+            %1 ore
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../tool/Utils.cpp" line="2293"/>
-        <location filename="../../tool/Utils.cpp" line="2294"/>
+        <location filename="../../tool/Utils.cpp" line="2293" />
+        <location filename="../../tool/Utils.cpp" line="2294" />
         <source>nDay</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            %1 giorno
+            %1 giorni
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../tool/Utils.cpp" line="2295"/>
+        <location filename="../../tool/Utils.cpp" line="2295" />
         <source>nWeek</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            %1 settimana
+            %1 settimane
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1899"/>
+        <location filename="../../tool/Utils.cpp" line="1899" />
         <source>contact_presence_status_available</source>
-        <translation type="unfinished"></translation>
+        <translation>Disponibile</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1905"/>
+        <location filename="../../tool/Utils.cpp" line="1905" />
         <source>contact_presence_status_busy</source>
-        <translation type="unfinished"></translation>
+        <translation>Occupato</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1908"/>
+        <location filename="../../tool/Utils.cpp" line="1908" />
         <source>contact_presence_status_do_not_disturb</source>
-        <translation type="unfinished"></translation>
+        <translation>Non disturbare</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1911"/>
+        <location filename="../../tool/Utils.cpp" line="1911" />
         <source>contact_presence_status_offline</source>
-        <translation type="unfinished"></translation>
+        <translation>Non in linea</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1902"/>
+        <location filename="../../tool/Utils.cpp" line="1902" />
         <source>contact_presence_status_away</source>
-        <translation type="unfinished"></translation>
+        <translation>Assente</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="200"/>
+        <location filename="../../tool/Utils.cpp" line="200" />
         <source>information_popup_call_not_created_message</source>
-        <extracomment>&quot;L&apos;appel n&apos;a pas pu être créé&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"L'appel n'a pas pu être créé"</extracomment>
+        <translation>Impossibile effettuare la chiamata</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="201"/>
-        <location filename="../../tool/Utils.cpp" line="212"/>
-        <location filename="../../tool/Utils.cpp" line="1675"/>
+        <location filename="../../tool/Utils.cpp" line="201" />
+        <location filename="../../tool/Utils.cpp" line="212" />
+        <location filename="../../tool/Utils.cpp" line="1675" />
         <source>information_popup_error_title</source>
         <extracomment>Failed to create 1-1 conversation with %1 !</extracomment>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="211"/>
+        <location filename="../../tool/Utils.cpp" line="211" />
         <source>information_popup_group_call_not_created_message</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile creare la chiamata di gruppo</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../tool/Utils.cpp" line="335"/>
+        <location filename="../../tool/Utils.cpp" line="335" />
         <source>number_of_years</source>
         <extracomment>%n an(s)</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            un anno
+            %1 anni
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../tool/Utils.cpp" line="338"/>
+        <location filename="../../tool/Utils.cpp" line="338" />
         <source>number_of_month</source>
-        <extracomment>&quot;%n mois&quot;</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <extracomment>"%n mois"</extracomment>
+        <translation>
+            un mese
+            %1 mesi
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../tool/Utils.cpp" line="341"/>
+        <location filename="../../tool/Utils.cpp" line="341" />
         <source>number_of_weeks</source>
         <extracomment>%n semaine(s)</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            una settimana
+            %1 settimane
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../tool/Utils.cpp" line="344"/>
+        <location filename="../../tool/Utils.cpp" line="344" />
         <source>number_of_days</source>
         <extracomment>%n jour(s)</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            un giorno
+            %1 giorni
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="370"/>
+        <location filename="../../tool/Utils.cpp" line="370" />
         <source>today</source>
-        <extracomment>&quot;Aujourd&apos;hui&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aujourd'hui"</extracomment>
+        <translation>Oggi</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="372"/>
+        <location filename="../../tool/Utils.cpp" line="372" />
         <source>yesterday</source>
-        <extracomment>&quot;Hier</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Hier</extracomment>
+        <translation>Ieri</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="397"/>
+        <location filename="../../tool/Utils.cpp" line="397" />
         <source>duration_tomorrow</source>
         <extracomment>Tomorrow</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Domani</translation>
     </message>
     <message numerus="yes">
-        <location filename="../../tool/Utils.cpp" line="400"/>
+        <location filename="../../tool/Utils.cpp" line="400" />
         <source>duration_number_of_days</source>
         <extracomment>%1 jour(s)</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            %n giorno
+            %n giorni
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="558"/>
+        <location filename="../../tool/Utils.cpp" line="558" />
         <source>call_zrtp_token_verification_possible_characters</source>
-        <extracomment>&quot;ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"</extracomment>
+        <translation>ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1676"/>
+        <location filename="../../tool/Utils.cpp" line="1676" />
         <source>information_popup_chatroom_creation_error_message</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile creare la conversazione con %1!</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2202"/>
+        <location filename="../../tool/Utils.cpp" line="2202" />
         <source>recorder_error</source>
         <extracomment>Error with the recorder</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Errore del registratore</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2063"/>
-        <location filename="../../tool/Utils.cpp" line="2095"/>
-        <location filename="../../tool/Utils.cpp" line="2139"/>
-        <location filename="../../tool/Utils.cpp" line="2204"/>
+        <location filename="../../tool/Utils.cpp" line="2063" />
+        <location filename="../../tool/Utils.cpp" line="2095" />
+        <location filename="../../tool/Utils.cpp" line="2139" />
+        <location filename="../../tool/Utils.cpp" line="2204" />
         <source>chat_error</source>
         <extracomment>Error creating or opening the chat
 ----------
 Error in the chat</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Errore nella chat</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2065"/>
-        <location filename="../../tool/Utils.cpp" line="2080"/>
-        <location filename="../../tool/Utils.cpp" line="2097"/>
-        <location filename="../../tool/Utils.cpp" line="2124"/>
-        <location filename="../../tool/Utils.cpp" line="2141"/>
-        <location filename="../../tool/Utils.cpp" line="2168"/>
-        <location filename="../../tool/Utils.cpp" line="2206"/>
-        <location filename="../../tool/Utils.cpp" line="2220"/>
+        <location filename="../../tool/Utils.cpp" line="2065" />
+        <location filename="../../tool/Utils.cpp" line="2080" />
+        <location filename="../../tool/Utils.cpp" line="2097" />
+        <location filename="../../tool/Utils.cpp" line="2124" />
+        <location filename="../../tool/Utils.cpp" line="2141" />
+        <location filename="../../tool/Utils.cpp" line="2168" />
+        <location filename="../../tool/Utils.cpp" line="2206" />
+        <location filename="../../tool/Utils.cpp" line="2220" />
         <source>info_popup_error_title</source>
         <extracomment>Error</extracomment>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2208"/>
+        <location filename="../../tool/Utils.cpp" line="2208" />
         <source>info_popup_send_voice_message_error_message</source>
         <extracomment>Could not send voice message : %1</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile inviare il messaggio vocale: %1</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="2222"/>
+        <location filename="../../tool/Utils.cpp" line="2222" />
         <source>info_popup_send_voice_message_sending_error_message</source>
         <extracomment>Failed to create message from record</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile creare il messaggio dalla registrazione</translation>
     </message>
 </context>
 <context>
     <name>Voicemail</name>
     <message>
-        <location filename="../../view/Control/Display/Contact/Voicemail.qml" line="30"/>
+        <location filename="../../view/Control/Display/Contact/Voicemail.qml" line="30" />
         <source>voicemail_accessible_name</source>
-        <extracomment>&quot;Voicemail&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Voicemail"</extracomment>
+        <translation>Segreteria telefonica</translation>
     </message>
 </context>
 <context>
     <name>WaitingRoom</name>
     <message>
-        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="98"/>
+        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="98" />
         <source>meeting_waiting_room_title</source>
         <extracomment>Participer à :</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Partecipa a:</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="120"/>
+        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="120" />
         <source>meeting_waiting_room_join</source>
-        <extracomment>&quot;Rejoindre&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Rejoindre"</extracomment>
+        <translation>Partecipa</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="131"/>
-        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="174"/>
+        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="131" />
+        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="174" />
         <source>cancel</source>
         <extracomment>Cancel</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="145"/>
+        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="145" />
         <source>meeting_waiting_room_joining_title</source>
-        <extracomment>&quot;Connexion à la réunion&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Connexion à la réunion"</extracomment>
+        <translation>Connessione alla riunione</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="155"/>
+        <location filename="../../view/Page/Main/Call/WaitingRoom.qml" line="155" />
         <source>meeting_waiting_room_joining_subtitle</source>
-        <extracomment>&quot;Vous allez rejoindre la réunion dans quelques instants…&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vous allez rejoindre la réunion dans quelques instants…"</extracomment>
+        <translation>Ti unirai alla riunione tra qualche istante…</translation>
     </message>
 </context>
 <context>
     <name>WelcomePage</name>
     <message>
-        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="17"/>
+        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="17" />
         <source>welcome_page_title</source>
-        <extracomment>&quot;Bienvenue&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Bienvenue"</extracomment>
+        <translation>Benvenuto</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="33"/>
+        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="33" />
         <source>welcome_page_subtitle</source>
-        <extracomment>&quot;sur %1&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"sur %1"</extracomment>
+        <translation>su %1</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="50"/>
+        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="50" />
         <source>welcome_carousel_skip</source>
-        <extracomment>&quot;Passer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Passer"</extracomment>
+        <translation>Salta</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="84"/>
+        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="84" />
         <source>welcome_page_1_message</source>
-        <extracomment>&quot;Une application de communication &lt;b&gt;sécurisée&lt;/b&gt;,&lt;br&gt; &lt;b&gt;open source&lt;/b&gt; et &lt;b&gt;française&lt;/b&gt;.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Une application de communication &lt;b&gt;sécurisée&lt;/b&gt;,&lt;br&gt; &lt;b&gt;open source&lt;/b&gt; et &lt;b&gt;française&lt;/b&gt;."</extracomment>
+        <translation>Un'applicazione di comunicazione &amp;lt;b&amp;gt;sicura&amp;lt;/b&amp;gt;,&amp;lt;br&amp;gt; &amp;lt;b&amp;gt;open source&amp;lt;/b&amp;gt; e &amp;lt;b&amp;gt;francese&amp;lt;/b&amp;gt;.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="86"/>
+        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="86" />
         <source>welcome_page_2_title</source>
-        <extracomment>&quot;Sécurisé&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Sécurisé"</extracomment>
+        <translation>Sicuro</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="88"/>
+        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="88" />
         <source>welcome_page_2_message</source>
-        <extracomment>&quot;Vos communications sont en sécurité grâce aux &lt;br&gt;&lt;b&gt;Chiffrement de bout en bout&lt;/b&gt;.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Vos communications sont en sécurité grâce aux &lt;br&gt;&lt;b&gt;Chiffrement de bout en bout&lt;/b&gt;."</extracomment>
+        <translation>Le tue comunicazioni sono al sicuro grazie alla &amp;lt;br&amp;gt;&amp;lt;b&amp;gt;Crittografia end-to-end&amp;lt;/b&amp;gt;.</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="90"/>
+        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="90" />
         <source>welcome_page_3_title</source>
-        <extracomment>&quot;Open Source&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Open Source"</extracomment>
+        <translation>Open Source</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="92"/>
+        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="92" />
         <source>welcome_page_3_message</source>
-        <extracomment>&quot;Une application open source et un &lt;b&gt;service gratuit&lt;/b&gt; &lt;br&gt;depuis &lt;b&gt;2001&lt;/b&gt;&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Une application open source et un &lt;b&gt;service gratuit&lt;/b&gt; &lt;br&gt;depuis &lt;b&gt;2001&lt;/b&gt;"</extracomment>
+        <translation>Un'applicazione open source e un &amp;lt;b&amp;gt;servizio gratuito&amp;lt;/b&amp;gt; &amp;lt;br&amp;gt;dal &amp;lt;b&amp;gt;2001&amp;lt;/b&amp;gt;</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="125"/>
+        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="125" />
         <source>next</source>
-        <extracomment>&quot;Suivant&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Suivant"</extracomment>
+        <translation>Avanti</translation>
     </message>
     <message>
-        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="127"/>
+        <location filename="../../view/Page/Main/Start/WelcomePage.qml" line="127" />
         <source>start</source>
-        <extracomment>&quot;Commencer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Commencer"</extracomment>
+        <translation>Inizia</translation>
     </message>
 </context>
 <context>
     <name>ZrtpAuthenticationDialog</name>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="71"/>
+        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="71" />
         <source>call_dialog_zrtp_validate_trust_title</source>
         <extracomment>Vérification de sécurité</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Verifica di sicurezza</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="89"/>
+        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="89" />
         <source>call_zrtp_sas_validation_skip</source>
-        <extracomment>&quot;Passer&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Passer"</extracomment>
+        <translation>Salta</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="134"/>
+        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="134" />
         <source>call_dialog_zrtp_validate_trust_warning_message</source>
-        <extracomment>&quot;Pour garantir le chiffrement, nous avons besoin de réauthentifier l’appareil de votre correspondant. Echangez vos codes :&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Pour garantir le chiffrement, nous avons besoin de réauthentifier l’appareil de votre correspondant. Echangez vos codes :"</extracomment>
+        <translation>Per garantire la crittografia, dobbiamo riautenticare il dispositivo del tuo contatto. Scambiate i codici:</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="136"/>
+        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="136" />
         <source>call_dialog_zrtp_validate_trust_message</source>
-        <extracomment>&quot;Pour garantir le chiffrement, nous avons besoin d’authentifier l’appareil de votre correspondant. Veuillez échanger vos codes : &quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Pour garantir le chiffrement, nous avons besoin d’authentifier l’appareil de votre correspondant. Veuillez échanger vos codes : "</extracomment>
+        <translation>Per garantire la crittografia, dobbiamo autenticare il dispositivo del tuo contatto. Scambiate i codici:</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="145"/>
+        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="145" />
         <source>call_dialog_zrtp_validate_trust_local_code_label</source>
-        <extracomment>&quot;Votre code :&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Votre code :"</extracomment>
+        <translation>Il tuo codice:</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="174"/>
+        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="174" />
         <source>call_dialog_zrtp_validate_trust_remote_code_label</source>
-        <extracomment>&quot;Code correspondant :&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Code correspondant :"</extracomment>
+        <translation>Codice del contatto:</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="222"/>
+        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="222" />
         <source>call_dialog_zrtp_validate_trust_letters_do_not_match_text</source>
-        <extracomment>&quot;Le code fourni ne correspond pas.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le code fourni ne correspond pas."</extracomment>
+        <translation>Il codice fornito non corrisponde.</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="233"/>
+        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="233" />
         <source>call_dialog_zrtp_security_alert_message</source>
-        <extracomment>&quot;La confidentialité de votre appel peut être compromise !&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"La confidentialité de votre appel peut être compromise !"</extracomment>
+        <translation>La riservatezza della tua chiamata potrebbe essere compromessa!</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="246"/>
+        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="246" />
         <source>call_dialog_zrtp_validate_trust_letters_do_not_match</source>
-        <extracomment>&quot;Aucune correspondance&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Aucune correspondance"</extracomment>
+        <translation>Nessuna corrispondenza</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="263"/>
+        <location filename="../../view/Control/Popup/Dialog/ZrtpAuthenticationDialog.qml" line="263" />
         <source>call_action_hang_up</source>
-        <extracomment>&quot;Raccrocher&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Raccrocher"</extracomment>
+        <translation>Riaggancia</translation>
     </message>
 </context>
 <context>
     <name>country</name>
     <message>
-        <location filename="../../tool/Utils.cpp" line="654"/>
+        <location filename="../../tool/Utils.cpp" line="654" />
         <source>Afghanistan</source>
-        <translation type="unfinished"></translation>
+        <translation>Afghanistan</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="658"/>
+        <location filename="../../tool/Utils.cpp" line="658" />
         <source>Albania</source>
-        <translation type="unfinished"></translation>
+        <translation>Albania</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="661"/>
+        <location filename="../../tool/Utils.cpp" line="661" />
         <source>Algeria</source>
-        <translation type="unfinished"></translation>
+        <translation>Algeria</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="664"/>
+        <location filename="../../tool/Utils.cpp" line="664" />
         <source>AmericanSamoa</source>
-        <translation type="unfinished"></translation>
+        <translation>Samoa Americane</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="668"/>
+        <location filename="../../tool/Utils.cpp" line="668" />
         <source>Andorra</source>
-        <translation type="unfinished"></translation>
+        <translation>Andorra</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="671"/>
+        <location filename="../../tool/Utils.cpp" line="671" />
         <source>Angola</source>
-        <translation type="unfinished"></translation>
+        <translation>Angola</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="674"/>
+        <location filename="../../tool/Utils.cpp" line="674" />
         <source>Anguilla</source>
-        <translation type="unfinished"></translation>
+        <translation>Anguilla</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="677"/>
+        <location filename="../../tool/Utils.cpp" line="677" />
         <source>AntiguaAndBarbuda</source>
-        <translation type="unfinished"></translation>
+        <translation>Antigua e Barbuda</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="681"/>
+        <location filename="../../tool/Utils.cpp" line="681" />
         <source>Argentina</source>
-        <translation type="unfinished"></translation>
+        <translation>Argentina</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="684"/>
+        <location filename="../../tool/Utils.cpp" line="684" />
         <source>Armenia</source>
-        <translation type="unfinished"></translation>
+        <translation>Armenia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="687"/>
+        <location filename="../../tool/Utils.cpp" line="687" />
         <source>Aruba</source>
-        <translation type="unfinished"></translation>
+        <translation>Aruba</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="690"/>
+        <location filename="../../tool/Utils.cpp" line="690" />
         <source>Australia</source>
-        <translation type="unfinished"></translation>
+        <translation>Australia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="693"/>
+        <location filename="../../tool/Utils.cpp" line="693" />
         <source>Austria</source>
-        <translation type="unfinished"></translation>
+        <translation>Austria</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="696"/>
+        <location filename="../../tool/Utils.cpp" line="696" />
         <source>Azerbaijan</source>
-        <translation type="unfinished"></translation>
+        <translation>Azerbaigian</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="699"/>
+        <location filename="../../tool/Utils.cpp" line="699" />
         <source>Bahamas</source>
-        <translation type="unfinished"></translation>
+        <translation>Bahamas</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="702"/>
+        <location filename="../../tool/Utils.cpp" line="702" />
         <source>Bahrain</source>
-        <translation type="unfinished"></translation>
+        <translation>Bahrein</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="705"/>
+        <location filename="../../tool/Utils.cpp" line="705" />
         <source>Bangladesh</source>
-        <translation type="unfinished"></translation>
+        <translation>Bangladesh</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="708"/>
+        <location filename="../../tool/Utils.cpp" line="708" />
         <source>Barbados</source>
-        <translation type="unfinished"></translation>
+        <translation>Barbados</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="711"/>
+        <location filename="../../tool/Utils.cpp" line="711" />
         <source>Belarus</source>
-        <translation type="unfinished"></translation>
+        <translation>Bielorussia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="714"/>
+        <location filename="../../tool/Utils.cpp" line="714" />
         <source>Belgium</source>
-        <translation type="unfinished"></translation>
+        <translation>Belgio</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="717"/>
+        <location filename="../../tool/Utils.cpp" line="717" />
         <source>Belize</source>
-        <translation type="unfinished"></translation>
+        <translation>Belize</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="720"/>
+        <location filename="../../tool/Utils.cpp" line="720" />
         <source>Benin</source>
-        <translation type="unfinished"></translation>
+        <translation>Benin</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="723"/>
+        <location filename="../../tool/Utils.cpp" line="723" />
         <source>Bermuda</source>
-        <translation type="unfinished"></translation>
+        <translation>Bermuda</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="726"/>
+        <location filename="../../tool/Utils.cpp" line="726" />
         <source>Bhutan</source>
-        <translation type="unfinished"></translation>
+        <translation>Bhutan</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="729"/>
+        <location filename="../../tool/Utils.cpp" line="729" />
         <source>Bolivia</source>
-        <translation type="unfinished"></translation>
+        <translation>Bolivia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="732"/>
+        <location filename="../../tool/Utils.cpp" line="732" />
         <source>BosniaAndHerzegowina</source>
-        <translation type="unfinished"></translation>
+        <translation>Bosnia ed Erzegovina</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="737"/>
+        <location filename="../../tool/Utils.cpp" line="737" />
         <source>Botswana</source>
-        <translation type="unfinished"></translation>
+        <translation>Botswana</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="740"/>
+        <location filename="../../tool/Utils.cpp" line="740" />
         <source>Brazil</source>
-        <translation type="unfinished"></translation>
+        <translation>Brasile</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="743"/>
+        <location filename="../../tool/Utils.cpp" line="743" />
         <source>Brunei</source>
-        <translation type="unfinished"></translation>
+        <translation>Brunei</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="746"/>
+        <location filename="../../tool/Utils.cpp" line="746" />
         <source>Bulgaria</source>
-        <translation type="unfinished"></translation>
+        <translation>Bulgaria</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="749"/>
+        <location filename="../../tool/Utils.cpp" line="749" />
         <source>BurkinaFaso</source>
-        <translation type="unfinished"></translation>
+        <translation>Burkina Faso</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="753"/>
+        <location filename="../../tool/Utils.cpp" line="753" />
         <source>Burundi</source>
-        <translation type="unfinished"></translation>
+        <translation>Burundi</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="756"/>
+        <location filename="../../tool/Utils.cpp" line="756" />
         <source>Cambodia</source>
-        <translation type="unfinished"></translation>
+        <translation>Cambogia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="759"/>
+        <location filename="../../tool/Utils.cpp" line="759" />
         <source>Cameroon</source>
-        <translation type="unfinished"></translation>
+        <translation>Camerun</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="762"/>
+        <location filename="../../tool/Utils.cpp" line="762" />
         <source>Canada</source>
-        <translation type="unfinished"></translation>
+        <translation>Canada</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="765"/>
+        <location filename="../../tool/Utils.cpp" line="765" />
         <source>CapeVerde</source>
-        <translation type="unfinished"></translation>
+        <translation>Capo Verde</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="768"/>
+        <location filename="../../tool/Utils.cpp" line="768" />
         <source>CaymanIslands</source>
-        <translation type="unfinished"></translation>
+        <translation>Isole Cayman</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="772"/>
+        <location filename="../../tool/Utils.cpp" line="772" />
         <source>CentralAfricanRepublic</source>
-        <translation type="unfinished"></translation>
+        <translation>Repubblica Centrafricana</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="777"/>
+        <location filename="../../tool/Utils.cpp" line="777" />
         <source>Chad</source>
-        <translation type="unfinished"></translation>
+        <translation>Ciad</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="780"/>
+        <location filename="../../tool/Utils.cpp" line="780" />
         <source>Chile</source>
-        <translation type="unfinished"></translation>
+        <translation>Cile</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="783"/>
+        <location filename="../../tool/Utils.cpp" line="783" />
         <source>China</source>
-        <translation type="unfinished"></translation>
+        <translation>Cina</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="786"/>
+        <location filename="../../tool/Utils.cpp" line="786" />
         <source>Colombia</source>
-        <translation type="unfinished"></translation>
+        <translation>Colombia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="789"/>
+        <location filename="../../tool/Utils.cpp" line="789" />
         <source>Comoros</source>
-        <translation type="unfinished"></translation>
+        <translation>Comore</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="792"/>
+        <location filename="../../tool/Utils.cpp" line="792" />
         <source>PeoplesRepublicOfCongo</source>
-        <translation type="unfinished"></translation>
+        <translation>Repubblica del Congo</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="802"/>
+        <location filename="../../tool/Utils.cpp" line="802" />
         <source>CookIslands</source>
-        <translation type="unfinished"></translation>
+        <translation>Isole Cook</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="806"/>
+        <location filename="../../tool/Utils.cpp" line="806" />
         <source>CostaRica</source>
-        <translation type="unfinished"></translation>
+        <translation>Costa Rica</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="809"/>
+        <location filename="../../tool/Utils.cpp" line="809" />
         <source>IvoryCoast</source>
-        <translation type="unfinished"></translation>
+        <translation>Costa d'Avorio</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="812"/>
+        <location filename="../../tool/Utils.cpp" line="812" />
         <source>Croatia</source>
-        <translation type="unfinished"></translation>
+        <translation>Croazia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="815"/>
+        <location filename="../../tool/Utils.cpp" line="815" />
         <source>Cuba</source>
-        <translation type="unfinished"></translation>
+        <translation>Cuba</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="818"/>
+        <location filename="../../tool/Utils.cpp" line="818" />
         <source>Cyprus</source>
-        <translation type="unfinished"></translation>
+        <translation>Cipro</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="821"/>
+        <location filename="../../tool/Utils.cpp" line="821" />
         <source>CzechRepublic</source>
-        <translation type="unfinished"></translation>
+        <translation>Repubblica Ceca</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="825"/>
+        <location filename="../../tool/Utils.cpp" line="825" />
         <source>Denmark</source>
-        <translation type="unfinished"></translation>
+        <translation>Danimarca</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="828"/>
+        <location filename="../../tool/Utils.cpp" line="828" />
         <source>Djibouti</source>
-        <translation type="unfinished"></translation>
+        <translation>Gibuti</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="831"/>
+        <location filename="../../tool/Utils.cpp" line="831" />
         <source>Dominica</source>
-        <translation type="unfinished"></translation>
+        <translation>Dominica</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="834"/>
+        <location filename="../../tool/Utils.cpp" line="834" />
         <source>DominicanRepublic</source>
-        <translation type="unfinished"></translation>
+        <translation>Repubblica Dominicana</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="838"/>
+        <location filename="../../tool/Utils.cpp" line="838" />
         <source>Ecuador</source>
-        <translation type="unfinished"></translation>
+        <translation>Ecuador</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="841"/>
+        <location filename="../../tool/Utils.cpp" line="841" />
         <source>Egypt</source>
-        <translation type="unfinished"></translation>
+        <translation>Egitto</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="844"/>
+        <location filename="../../tool/Utils.cpp" line="844" />
         <source>ElSalvador</source>
-        <translation type="unfinished"></translation>
+        <translation>El Salvador</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="847"/>
+        <location filename="../../tool/Utils.cpp" line="847" />
         <source>EquatorialGuinea</source>
-        <translation type="unfinished"></translation>
+        <translation>Guinea Equatoriale</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="851"/>
+        <location filename="../../tool/Utils.cpp" line="851" />
         <source>Eritrea</source>
-        <translation type="unfinished"></translation>
+        <translation>Eritrea</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="854"/>
+        <location filename="../../tool/Utils.cpp" line="854" />
         <source>Estonia</source>
-        <translation type="unfinished"></translation>
+        <translation>Estonia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="857"/>
+        <location filename="../../tool/Utils.cpp" line="857" />
         <source>Ethiopia</source>
-        <translation type="unfinished"></translation>
+        <translation>Etiopia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="860"/>
+        <location filename="../../tool/Utils.cpp" line="860" />
         <source>FalklandIslands</source>
-        <translation type="unfinished"></translation>
+        <translation>Isole Falkland</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="864"/>
+        <location filename="../../tool/Utils.cpp" line="864" />
         <source>FaroeIslands</source>
-        <translation type="unfinished"></translation>
+        <translation>Isole Fær Øer</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="868"/>
+        <location filename="../../tool/Utils.cpp" line="868" />
         <source>Fiji</source>
-        <translation type="unfinished"></translation>
+        <translation>Figi</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="871"/>
+        <location filename="../../tool/Utils.cpp" line="871" />
         <source>Finland</source>
-        <translation type="unfinished"></translation>
+        <translation>Finlandia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="874"/>
+        <location filename="../../tool/Utils.cpp" line="874" />
         <source>France</source>
-        <translation type="unfinished"></translation>
+        <translation>Francia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="877"/>
+        <location filename="../../tool/Utils.cpp" line="877" />
         <source>FrenchGuiana</source>
-        <translation type="unfinished"></translation>
+        <translation>Guyana Francese</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="881"/>
+        <location filename="../../tool/Utils.cpp" line="881" />
         <source>FrenchPolynesia</source>
-        <translation type="unfinished"></translation>
+        <translation>Polinesia Francese</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="885"/>
+        <location filename="../../tool/Utils.cpp" line="885" />
         <source>Gabon</source>
-        <translation type="unfinished"></translation>
+        <translation>Gabon</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="888"/>
+        <location filename="../../tool/Utils.cpp" line="888" />
         <source>Gambia</source>
-        <translation type="unfinished"></translation>
+        <translation>Gambia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="891"/>
+        <location filename="../../tool/Utils.cpp" line="891" />
         <source>Georgia</source>
-        <translation type="unfinished"></translation>
+        <translation>Georgia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="894"/>
+        <location filename="../../tool/Utils.cpp" line="894" />
         <source>Germany</source>
-        <translation type="unfinished"></translation>
+        <translation>Germania</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="897"/>
+        <location filename="../../tool/Utils.cpp" line="897" />
         <source>Ghana</source>
-        <translation type="unfinished"></translation>
+        <translation>Ghana</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="900"/>
+        <location filename="../../tool/Utils.cpp" line="900" />
         <source>Gibraltar</source>
-        <translation type="unfinished"></translation>
+        <translation>Gibilterra</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="903"/>
+        <location filename="../../tool/Utils.cpp" line="903" />
         <source>Greece</source>
-        <translation type="unfinished"></translation>
+        <translation>Grecia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="906"/>
+        <location filename="../../tool/Utils.cpp" line="906" />
         <source>Greenland</source>
-        <translation type="unfinished"></translation>
+        <translation>Groenlandia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="909"/>
+        <location filename="../../tool/Utils.cpp" line="909" />
         <source>Grenada</source>
-        <translation type="unfinished"></translation>
+        <translation>Grenada</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="912"/>
+        <location filename="../../tool/Utils.cpp" line="912" />
         <source>Guadeloupe</source>
-        <translation type="unfinished"></translation>
+        <translation>Guadalupa</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="915"/>
+        <location filename="../../tool/Utils.cpp" line="915" />
         <source>Guam</source>
-        <translation type="unfinished"></translation>
+        <translation>Guam</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="918"/>
+        <location filename="../../tool/Utils.cpp" line="918" />
         <source>Guatemala</source>
-        <translation type="unfinished"></translation>
+        <translation>Guatemala</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="921"/>
+        <location filename="../../tool/Utils.cpp" line="921" />
         <source>Guinea</source>
-        <translation type="unfinished"></translation>
+        <translation>Guinea</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="924"/>
+        <location filename="../../tool/Utils.cpp" line="924" />
         <source>GuineaBissau</source>
-        <translation type="unfinished"></translation>
+        <translation>Guinea-Bissau</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="928"/>
+        <location filename="../../tool/Utils.cpp" line="928" />
         <source>Guyana</source>
-        <translation type="unfinished"></translation>
+        <translation>Guyana</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="931"/>
+        <location filename="../../tool/Utils.cpp" line="931" />
         <source>Haiti</source>
-        <translation type="unfinished"></translation>
+        <translation>Haiti</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="934"/>
+        <location filename="../../tool/Utils.cpp" line="934" />
         <source>Honduras</source>
-        <translation type="unfinished"></translation>
+        <translation>Honduras</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="797"/>
+        <location filename="../../tool/Utils.cpp" line="797" />
         <source>DemocraticRepublicOfCongo</source>
-        <translation type="unfinished"></translation>
+        <translation>Repubblica Democratica del Congo</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="937"/>
+        <location filename="../../tool/Utils.cpp" line="937" />
         <source>HongKong</source>
-        <translation type="unfinished"></translation>
+        <translation>Hong Kong</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="940"/>
+        <location filename="../../tool/Utils.cpp" line="940" />
         <source>Hungary</source>
-        <translation type="unfinished"></translation>
+        <translation>Ungheria</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="943"/>
+        <location filename="../../tool/Utils.cpp" line="943" />
         <source>Iceland</source>
-        <translation type="unfinished"></translation>
+        <translation>Islanda</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="946"/>
+        <location filename="../../tool/Utils.cpp" line="946" />
         <source>India</source>
-        <translation type="unfinished"></translation>
+        <translation>India</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="949"/>
+        <location filename="../../tool/Utils.cpp" line="949" />
         <source>Indonesia</source>
-        <translation type="unfinished"></translation>
+        <translation>Indonesia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="952"/>
+        <location filename="../../tool/Utils.cpp" line="952" />
         <source>Iran</source>
-        <translation type="unfinished"></translation>
+        <translation>Iran</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="955"/>
+        <location filename="../../tool/Utils.cpp" line="955" />
         <source>Iraq</source>
-        <translation type="unfinished"></translation>
+        <translation>Iraq</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="958"/>
+        <location filename="../../tool/Utils.cpp" line="958" />
         <source>Ireland</source>
-        <translation type="unfinished"></translation>
+        <translation>Irlanda</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="961"/>
+        <location filename="../../tool/Utils.cpp" line="961" />
         <source>Israel</source>
-        <translation type="unfinished"></translation>
+        <translation>Israele</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="964"/>
+        <location filename="../../tool/Utils.cpp" line="964" />
         <source>Italy</source>
-        <translation type="unfinished"></translation>
+        <translation>Italia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="967"/>
+        <location filename="../../tool/Utils.cpp" line="967" />
         <source>Jamaica</source>
-        <translation type="unfinished"></translation>
+        <translation>Giamaica</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="970"/>
+        <location filename="../../tool/Utils.cpp" line="970" />
         <source>Japan</source>
-        <translation type="unfinished"></translation>
+        <translation>Giappone</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="973"/>
+        <location filename="../../tool/Utils.cpp" line="973" />
         <source>Jordan</source>
-        <translation type="unfinished"></translation>
+        <translation>Giordania</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="976"/>
+        <location filename="../../tool/Utils.cpp" line="976" />
         <source>Kazakhstan</source>
-        <translation type="unfinished"></translation>
+        <translation>Kazakistan</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="979"/>
+        <location filename="../../tool/Utils.cpp" line="979" />
         <source>Kenya</source>
-        <translation type="unfinished"></translation>
+        <translation>Kenya</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="982"/>
+        <location filename="../../tool/Utils.cpp" line="982" />
         <source>Kiribati</source>
-        <translation type="unfinished"></translation>
+        <translation>Kiribati</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="985"/>
+        <location filename="../../tool/Utils.cpp" line="985" />
         <source>DemocraticRepublicOfKorea</source>
-        <translation type="unfinished"></translation>
+        <translation>Repubblica Popolare Democratica di Corea</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="990"/>
+        <location filename="../../tool/Utils.cpp" line="990" />
         <source>RepublicOfKorea</source>
-        <translation type="unfinished"></translation>
+        <translation>Repubblica di Corea</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="994"/>
+        <location filename="../../tool/Utils.cpp" line="994" />
         <source>Kuwait</source>
-        <translation type="unfinished"></translation>
+        <translation>Kuwait</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="997"/>
+        <location filename="../../tool/Utils.cpp" line="997" />
         <source>Kyrgyzstan</source>
-        <translation type="unfinished"></translation>
+        <translation>Kirghizistan</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1000"/>
+        <location filename="../../tool/Utils.cpp" line="1000" />
         <source>Laos</source>
-        <translation type="unfinished"></translation>
+        <translation>Laos</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1003"/>
+        <location filename="../../tool/Utils.cpp" line="1003" />
         <source>Latvia</source>
-        <translation type="unfinished"></translation>
+        <translation>Lettonia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1006"/>
+        <location filename="../../tool/Utils.cpp" line="1006" />
         <source>Lebanon</source>
-        <translation type="unfinished"></translation>
+        <translation>Libano</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1009"/>
+        <location filename="../../tool/Utils.cpp" line="1009" />
         <source>Lesotho</source>
-        <translation type="unfinished"></translation>
+        <translation>Lesotho</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1012"/>
+        <location filename="../../tool/Utils.cpp" line="1012" />
         <source>Liberia</source>
-        <translation type="unfinished"></translation>
+        <translation>Liberia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1015"/>
+        <location filename="../../tool/Utils.cpp" line="1015" />
         <source>Libya</source>
-        <translation type="unfinished"></translation>
+        <translation>Libia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1018"/>
+        <location filename="../../tool/Utils.cpp" line="1018" />
         <source>Liechtenstein</source>
-        <translation type="unfinished"></translation>
+        <translation>Liechtenstein</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1022"/>
+        <location filename="../../tool/Utils.cpp" line="1022" />
         <source>Lithuania</source>
-        <translation type="unfinished"></translation>
+        <translation>Lituania</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1025"/>
+        <location filename="../../tool/Utils.cpp" line="1025" />
         <source>Luxembourg</source>
-        <translation type="unfinished"></translation>
+        <translation>Lussemburgo</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1028"/>
+        <location filename="../../tool/Utils.cpp" line="1028" />
         <source>Macau</source>
-        <translation type="unfinished"></translation>
+        <translation>Macao</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1031"/>
+        <location filename="../../tool/Utils.cpp" line="1031" />
         <source>Macedonia</source>
-        <translation type="unfinished"></translation>
+        <translation>Macedonia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1034"/>
+        <location filename="../../tool/Utils.cpp" line="1034" />
         <source>Madagascar</source>
-        <translation type="unfinished"></translation>
+        <translation>Madagascar</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1037"/>
+        <location filename="../../tool/Utils.cpp" line="1037" />
         <source>Malawi</source>
-        <translation type="unfinished"></translation>
+        <translation>Malawi</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1040"/>
+        <location filename="../../tool/Utils.cpp" line="1040" />
         <source>Malaysia</source>
-        <translation type="unfinished"></translation>
+        <translation>Malaysia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1043"/>
+        <location filename="../../tool/Utils.cpp" line="1043" />
         <source>Maldives</source>
-        <translation type="unfinished"></translation>
+        <translation>Maldive</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1046"/>
+        <location filename="../../tool/Utils.cpp" line="1046" />
         <source>Mali</source>
-        <translation type="unfinished"></translation>
+        <translation>Mali</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1049"/>
+        <location filename="../../tool/Utils.cpp" line="1049" />
         <source>Malta</source>
-        <translation type="unfinished"></translation>
+        <translation>Malta</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1052"/>
+        <location filename="../../tool/Utils.cpp" line="1052" />
         <source>MarshallIslands</source>
-        <translation type="unfinished"></translation>
+        <translation>Isole Marshall</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1056"/>
+        <location filename="../../tool/Utils.cpp" line="1056" />
         <source>Martinique</source>
-        <translation type="unfinished"></translation>
+        <translation>Martinica</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1059"/>
+        <location filename="../../tool/Utils.cpp" line="1059" />
         <source>Mauritania</source>
-        <translation type="unfinished"></translation>
+        <translation>Mauritania</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1062"/>
+        <location filename="../../tool/Utils.cpp" line="1062" />
         <source>Mauritius</source>
-        <translation type="unfinished"></translation>
+        <translation>Mauritius</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1065"/>
+        <location filename="../../tool/Utils.cpp" line="1065" />
         <source>Mayotte</source>
-        <translation type="unfinished"></translation>
+        <translation>Mayotte</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1068"/>
+        <location filename="../../tool/Utils.cpp" line="1068" />
         <source>Mexico</source>
-        <translation type="unfinished"></translation>
+        <translation>Messico</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1071"/>
+        <location filename="../../tool/Utils.cpp" line="1071" />
         <source>Micronesia</source>
-        <translation type="unfinished"></translation>
+        <translation>Micronesia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1074"/>
+        <location filename="../../tool/Utils.cpp" line="1074" />
         <source>Moldova</source>
-        <translation type="unfinished"></translation>
+        <translation>Moldavia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1077"/>
+        <location filename="../../tool/Utils.cpp" line="1077" />
         <source>Monaco</source>
-        <translation type="unfinished"></translation>
+        <translation>Monaco</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1080"/>
+        <location filename="../../tool/Utils.cpp" line="1080" />
         <source>Mongolia</source>
-        <translation type="unfinished"></translation>
+        <translation>Mongolia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1083"/>
+        <location filename="../../tool/Utils.cpp" line="1083" />
         <source>Montenegro</source>
-        <translation type="unfinished"></translation>
+        <translation>Montenegro</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1086"/>
+        <location filename="../../tool/Utils.cpp" line="1086" />
         <source>Montserrat</source>
-        <translation type="unfinished"></translation>
+        <translation>Montserrat</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1089"/>
+        <location filename="../../tool/Utils.cpp" line="1089" />
         <source>Morocco</source>
-        <translation type="unfinished"></translation>
+        <translation>Marocco</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1092"/>
+        <location filename="../../tool/Utils.cpp" line="1092" />
         <source>Mozambique</source>
-        <translation type="unfinished"></translation>
+        <translation>Mozambico</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1095"/>
+        <location filename="../../tool/Utils.cpp" line="1095" />
         <source>Myanmar</source>
-        <translation type="unfinished"></translation>
+        <translation>Myanmar</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1098"/>
+        <location filename="../../tool/Utils.cpp" line="1098" />
         <source>Namibia</source>
-        <translation type="unfinished"></translation>
+        <translation>Namibia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1101"/>
+        <location filename="../../tool/Utils.cpp" line="1101" />
         <source>NauruCountry</source>
-        <translation type="unfinished"></translation>
+        <translation>Nauru</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1105"/>
+        <location filename="../../tool/Utils.cpp" line="1105" />
         <source>Nepal</source>
-        <translation type="unfinished"></translation>
+        <translation>Nepal</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1108"/>
+        <location filename="../../tool/Utils.cpp" line="1108" />
         <source>Netherlands</source>
-        <translation type="unfinished"></translation>
+        <translation>Paesi Bassi</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1112"/>
+        <location filename="../../tool/Utils.cpp" line="1112" />
         <source>NewCaledonia</source>
-        <translation type="unfinished"></translation>
+        <translation>Nuova Caledonia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1116"/>
+        <location filename="../../tool/Utils.cpp" line="1116" />
         <source>NewZealand</source>
-        <translation type="unfinished"></translation>
+        <translation>Nuova Zelanda</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1119"/>
+        <location filename="../../tool/Utils.cpp" line="1119" />
         <source>Nicaragua</source>
-        <translation type="unfinished"></translation>
+        <translation>Nicaragua</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1122"/>
+        <location filename="../../tool/Utils.cpp" line="1122" />
         <source>Niger</source>
-        <translation type="unfinished"></translation>
+        <translation>Niger</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1125"/>
+        <location filename="../../tool/Utils.cpp" line="1125" />
         <source>Nigeria</source>
-        <translation type="unfinished"></translation>
+        <translation>Nigeria</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1128"/>
+        <location filename="../../tool/Utils.cpp" line="1128" />
         <source>Niue</source>
-        <translation type="unfinished"></translation>
+        <translation>Niue</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1131"/>
+        <location filename="../../tool/Utils.cpp" line="1131" />
         <source>NorfolkIsland</source>
-        <translation type="unfinished"></translation>
+        <translation>Isola Norfolk</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1135"/>
+        <location filename="../../tool/Utils.cpp" line="1135" />
         <source>NorthernMarianaIslands</source>
-        <translation type="unfinished"></translation>
+        <translation>Isole Marianne Settentrionali</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1140"/>
+        <location filename="../../tool/Utils.cpp" line="1140" />
         <source>Norway</source>
-        <translation type="unfinished"></translation>
+        <translation>Norvegia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1143"/>
+        <location filename="../../tool/Utils.cpp" line="1143" />
         <source>Oman</source>
-        <translation type="unfinished"></translation>
+        <translation>Oman</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1146"/>
+        <location filename="../../tool/Utils.cpp" line="1146" />
         <source>Pakistan</source>
-        <translation type="unfinished"></translation>
+        <translation>Pakistan</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1149"/>
+        <location filename="../../tool/Utils.cpp" line="1149" />
         <source>Palau</source>
-        <translation type="unfinished"></translation>
+        <translation>Palau</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1152"/>
+        <location filename="../../tool/Utils.cpp" line="1152" />
         <source>PalestinianTerritories</source>
-        <translation type="unfinished"></translation>
+        <translation>Territori Palestinesi</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1157"/>
+        <location filename="../../tool/Utils.cpp" line="1157" />
         <source>Panama</source>
-        <translation type="unfinished"></translation>
+        <translation>Panama</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1160"/>
+        <location filename="../../tool/Utils.cpp" line="1160" />
         <source>PapuaNewGuinea</source>
-        <translation type="unfinished"></translation>
+        <translation>Papua Nuova Guinea</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1164"/>
+        <location filename="../../tool/Utils.cpp" line="1164" />
         <source>Paraguay</source>
-        <translation type="unfinished"></translation>
+        <translation>Paraguay</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1167"/>
+        <location filename="../../tool/Utils.cpp" line="1167" />
         <source>Peru</source>
-        <translation type="unfinished"></translation>
+        <translation>Perù</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1170"/>
+        <location filename="../../tool/Utils.cpp" line="1170" />
         <source>Philippines</source>
-        <translation type="unfinished"></translation>
+        <translation>Filippine</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1174"/>
+        <location filename="../../tool/Utils.cpp" line="1174" />
         <source>Poland</source>
-        <translation type="unfinished"></translation>
+        <translation>Polonia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1177"/>
+        <location filename="../../tool/Utils.cpp" line="1177" />
         <source>Portugal</source>
-        <translation type="unfinished"></translation>
+        <translation>Portogallo</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1180"/>
+        <location filename="../../tool/Utils.cpp" line="1180" />
         <source>PuertoRico</source>
-        <translation type="unfinished"></translation>
+        <translation>Porto Rico</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1183"/>
+        <location filename="../../tool/Utils.cpp" line="1183" />
         <source>Qatar</source>
-        <translation type="unfinished"></translation>
+        <translation>Qatar</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1186"/>
+        <location filename="../../tool/Utils.cpp" line="1186" />
         <source>Reunion</source>
-        <translation type="unfinished"></translation>
+        <translation>Riunione</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1189"/>
+        <location filename="../../tool/Utils.cpp" line="1189" />
         <source>Romania</source>
-        <translation type="unfinished"></translation>
+        <translation>Romania</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1192"/>
+        <location filename="../../tool/Utils.cpp" line="1192" />
         <source>RussianFederation</source>
-        <translation type="unfinished"></translation>
+        <translation>Federazione Russa</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1196"/>
+        <location filename="../../tool/Utils.cpp" line="1196" />
         <source>Rwanda</source>
-        <translation type="unfinished"></translation>
+        <translation>Ruanda</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1199"/>
+        <location filename="../../tool/Utils.cpp" line="1199" />
         <source>SaintHelena</source>
-        <translation type="unfinished"></translation>
+        <translation>Sant'Elena</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1203"/>
+        <location filename="../../tool/Utils.cpp" line="1203" />
         <source>SaintKittsAndNevis</source>
-        <translation type="unfinished"></translation>
+        <translation>Saint Kitts e Nevis</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1207"/>
+        <location filename="../../tool/Utils.cpp" line="1207" />
         <source>SaintLucia</source>
-        <translation type="unfinished"></translation>
+        <translation>Santa Lucia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1210"/>
+        <location filename="../../tool/Utils.cpp" line="1210" />
         <source>SaintPierreAndMiquelon</source>
-        <translation type="unfinished"></translation>
+        <translation>Saint-Pierre e Miquelon</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1215"/>
+        <location filename="../../tool/Utils.cpp" line="1215" />
         <source>SaintVincentAndTheGrenadines</source>
-        <translation type="unfinished"></translation>
+        <translation>Saint Vincent e Grenadine</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1220"/>
+        <location filename="../../tool/Utils.cpp" line="1220" />
         <source>Samoa</source>
-        <translation type="unfinished"></translation>
+        <translation>Samoa</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1223"/>
+        <location filename="../../tool/Utils.cpp" line="1223" />
         <source>SanMarino</source>
-        <translation type="unfinished"></translation>
+        <translation>San Marino</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1226"/>
+        <location filename="../../tool/Utils.cpp" line="1226" />
         <source>SaoTomeAndPrincipe</source>
-        <translation type="unfinished"></translation>
+        <translation>São Tomé e Príncipe</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1230"/>
+        <location filename="../../tool/Utils.cpp" line="1230" />
         <source>SaudiArabia</source>
-        <translation type="unfinished"></translation>
+        <translation>Arabia Saudita</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1234"/>
+        <location filename="../../tool/Utils.cpp" line="1234" />
         <source>Senegal</source>
-        <translation type="unfinished"></translation>
+        <translation>Senegal</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1237"/>
+        <location filename="../../tool/Utils.cpp" line="1237" />
         <source>Serbia</source>
-        <translation type="unfinished"></translation>
+        <translation>Serbia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1240"/>
+        <location filename="../../tool/Utils.cpp" line="1240" />
         <source>Seychelles</source>
-        <translation type="unfinished"></translation>
+        <translation>Seychelles</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1243"/>
+        <location filename="../../tool/Utils.cpp" line="1243" />
         <source>SierraLeone</source>
-        <translation type="unfinished"></translation>
+        <translation>Sierra Leone</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1247"/>
+        <location filename="../../tool/Utils.cpp" line="1247" />
         <source>Singapore</source>
-        <translation type="unfinished"></translation>
+        <translation>Singapore</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1250"/>
+        <location filename="../../tool/Utils.cpp" line="1250" />
         <source>Slovakia</source>
-        <translation type="unfinished"></translation>
+        <translation>Slovacchia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1253"/>
+        <location filename="../../tool/Utils.cpp" line="1253" />
         <source>Slovenia</source>
-        <translation type="unfinished"></translation>
+        <translation>Slovenia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1256"/>
+        <location filename="../../tool/Utils.cpp" line="1256" />
         <source>SolomonIslands</source>
-        <translation type="unfinished"></translation>
+        <translation>Isole Salomone</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1260"/>
+        <location filename="../../tool/Utils.cpp" line="1260" />
         <source>Somalia</source>
-        <translation type="unfinished"></translation>
+        <translation>Somalia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1263"/>
+        <location filename="../../tool/Utils.cpp" line="1263" />
         <source>SouthAfrica</source>
-        <translation type="unfinished"></translation>
+        <translation>Sudafrica</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1267"/>
+        <location filename="../../tool/Utils.cpp" line="1267" />
         <source>Spain</source>
-        <translation type="unfinished"></translation>
+        <translation>Spagna</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1270"/>
+        <location filename="../../tool/Utils.cpp" line="1270" />
         <source>SriLanka</source>
-        <translation type="unfinished"></translation>
+        <translation>Sri Lanka</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1273"/>
+        <location filename="../../tool/Utils.cpp" line="1273" />
         <source>Sudan</source>
-        <translation type="unfinished"></translation>
+        <translation>Sudan</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1276"/>
+        <location filename="../../tool/Utils.cpp" line="1276" />
         <source>Suriname</source>
-        <translation type="unfinished"></translation>
+        <translation>Suriname</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1279"/>
+        <location filename="../../tool/Utils.cpp" line="1279" />
         <source>Swaziland</source>
-        <translation type="unfinished"></translation>
+        <translation>Swaziland</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1282"/>
+        <location filename="../../tool/Utils.cpp" line="1282" />
         <source>Sweden</source>
-        <translation type="unfinished"></translation>
+        <translation>Svezia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1285"/>
+        <location filename="../../tool/Utils.cpp" line="1285" />
         <source>Switzerland</source>
-        <translation type="unfinished"></translation>
+        <translation>Svizzera</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1289"/>
+        <location filename="../../tool/Utils.cpp" line="1289" />
         <source>Syria</source>
-        <translation type="unfinished"></translation>
+        <translation>Siria</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1292"/>
+        <location filename="../../tool/Utils.cpp" line="1292" />
         <source>Taiwan</source>
-        <translation type="unfinished"></translation>
+        <translation>Taiwan</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1295"/>
+        <location filename="../../tool/Utils.cpp" line="1295" />
         <source>Tajikistan</source>
-        <translation type="unfinished"></translation>
+        <translation>Tagikistan</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1298"/>
+        <location filename="../../tool/Utils.cpp" line="1298" />
         <source>Tanzania</source>
-        <translation type="unfinished"></translation>
+        <translation>Tanzania</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1301"/>
+        <location filename="../../tool/Utils.cpp" line="1301" />
         <source>Thailand</source>
-        <translation type="unfinished"></translation>
+        <translation>Tailandia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1304"/>
+        <location filename="../../tool/Utils.cpp" line="1304" />
         <source>Togo</source>
-        <translation type="unfinished"></translation>
+        <translation>Togo</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1307"/>
+        <location filename="../../tool/Utils.cpp" line="1307" />
         <source>Tokelau</source>
-        <translation type="unfinished"></translation>
+        <translation>Tokelau</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1310"/>
+        <location filename="../../tool/Utils.cpp" line="1310" />
         <source>Tonga</source>
-        <translation type="unfinished"></translation>
+        <translation>Tonga</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1313"/>
+        <location filename="../../tool/Utils.cpp" line="1313" />
         <source>TrinidadAndTobago</source>
-        <translation type="unfinished"></translation>
+        <translation>Trinidad e Tobago</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1317"/>
+        <location filename="../../tool/Utils.cpp" line="1317" />
         <source>Tunisia</source>
-        <translation type="unfinished"></translation>
+        <translation>Tunisia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1320"/>
+        <location filename="../../tool/Utils.cpp" line="1320" />
         <source>Turkey</source>
-        <translation type="unfinished"></translation>
+        <translation>Turchia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1323"/>
+        <location filename="../../tool/Utils.cpp" line="1323" />
         <source>Turkmenistan</source>
-        <translation type="unfinished"></translation>
+        <translation>Turkmenistan</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1327"/>
+        <location filename="../../tool/Utils.cpp" line="1327" />
         <source>TurksAndCaicosIslands</source>
-        <translation type="unfinished"></translation>
+        <translation>Isole Turks e Caicos</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1332"/>
+        <location filename="../../tool/Utils.cpp" line="1332" />
         <source>Tuvalu</source>
-        <translation type="unfinished"></translation>
+        <translation>Tuvalu</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1335"/>
+        <location filename="../../tool/Utils.cpp" line="1335" />
         <source>Uganda</source>
-        <translation type="unfinished"></translation>
+        <translation>Uganda</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1338"/>
+        <location filename="../../tool/Utils.cpp" line="1338" />
         <source>Ukraine</source>
-        <translation type="unfinished"></translation>
+        <translation>Ucraina</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1341"/>
+        <location filename="../../tool/Utils.cpp" line="1341" />
         <source>UnitedArabEmirates</source>
-        <translation type="unfinished"></translation>
+        <translation>Emirati Arabi Uniti</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1345"/>
+        <location filename="../../tool/Utils.cpp" line="1345" />
         <source>UnitedKingdom</source>
-        <translation type="unfinished"></translation>
+        <translation>Regno Unito</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1349"/>
+        <location filename="../../tool/Utils.cpp" line="1349" />
         <source>UnitedStates</source>
-        <translation type="unfinished"></translation>
+        <translation>Stati Uniti</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1353"/>
+        <location filename="../../tool/Utils.cpp" line="1353" />
         <source>Uruguay</source>
-        <translation type="unfinished"></translation>
+        <translation>Uruguay</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1356"/>
+        <location filename="../../tool/Utils.cpp" line="1356" />
         <source>Uzbekistan</source>
-        <translation type="unfinished"></translation>
+        <translation>Uzbekistan</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1359"/>
+        <location filename="../../tool/Utils.cpp" line="1359" />
         <source>Vanuatu</source>
-        <translation type="unfinished"></translation>
+        <translation>Vanuatu</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1362"/>
+        <location filename="../../tool/Utils.cpp" line="1362" />
         <source>Venezuela</source>
-        <translation type="unfinished"></translation>
+        <translation>Venezuela</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1365"/>
+        <location filename="../../tool/Utils.cpp" line="1365" />
         <source>Vietnam</source>
-        <translation type="unfinished"></translation>
+        <translation>Vietnam</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1368"/>
+        <location filename="../../tool/Utils.cpp" line="1368" />
         <source>WallisAndFutunaIslands</source>
-        <translation type="unfinished"></translation>
+        <translation>Wallis e Futuna</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1373"/>
+        <location filename="../../tool/Utils.cpp" line="1373" />
         <source>Yemen</source>
-        <translation type="unfinished"></translation>
+        <translation>Yemen</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1376"/>
+        <location filename="../../tool/Utils.cpp" line="1376" />
         <source>Zambia</source>
-        <translation type="unfinished"></translation>
+        <translation>Zambia</translation>
     </message>
     <message>
-        <location filename="../../tool/Utils.cpp" line="1379"/>
+        <location filename="../../tool/Utils.cpp" line="1379" />
         <source>Zimbabwe</source>
-        <translation type="unfinished"></translation>
+        <translation>Zimbabwe</translation>
     </message>
 </context>
 <context>
     <name>utils</name>
     <message numerus="yes">
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="491"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="491" />
         <source>formatYears</source>
-        <extracomment>&apos;%1 year&apos;</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <extracomment>'%1 year'</extracomment>
+        <translation>
+            un anno
+            %1 anni
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="495"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="495" />
         <source>formatMonths</source>
-        <extracomment>&apos;%1 month&apos;</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <extracomment>'%1 month'</extracomment>
+        <translation>
+            un mese
+            %1 mesi
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="499"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="499" />
         <source>formatWeeks</source>
-        <extracomment>&apos;%1 week&apos;</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <extracomment>'%1 week'</extracomment>
+        <translation>
+            una settimana
+            %1 settimane
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="503"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="503" />
         <source>formatDays</source>
-        <extracomment>&apos;%1 day&apos;</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <extracomment>'%1 day'</extracomment>
+        <translation>
+            un giorno
+            %1 giorni
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="509"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="509" />
         <source>formatHours</source>
-        <extracomment>&apos;%1 hour&apos;</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <extracomment>'%1 hour'</extracomment>
+        <translation>
+            un'ora
+            %1 ore
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="511"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="511" />
         <source>formatMinutes</source>
-        <extracomment>&apos;%1 minute&apos;</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <extracomment>'%1 minute'</extracomment>
+        <translation>
+            un minuto
+            %1 minuti
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="513"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="513" />
         <source>formatSeconds</source>
-        <extracomment>&apos;%1 second&apos;</extracomment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <extracomment>'%1 second'</extracomment>
+        <translation>
+            un secondo
+            %1 secondi
+        <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="730"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="730" />
         <source>codec_install</source>
-        <extracomment>&quot;Installation de codec&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Installation de codec"</extracomment>
+        <translation>Installazione codec</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="732"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="732" />
         <source>download_codec</source>
-        <extracomment>&quot;Télécharger le codec %1 (%2) ?&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Télécharger le codec %1 (%2) ?"</extracomment>
+        <translation>Scaricare il codec %1 (%2)?</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="739"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="739" />
         <source>information_popup_success_title</source>
-        <extracomment>&quot;Succès&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Succès"</extracomment>
+        <translation>Operazione riuscita</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="741"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="741" />
         <source>information_popup_codec_install_success_text</source>
-        <extracomment>&quot;Le codec a été installé avec succès.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le codec a été installé avec succès."</extracomment>
+        <translation>Il codec è stato installato con successo.</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="745"/>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="754"/>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="762"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="745" />
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="754" />
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="762" />
         <source>information_popup_error_title</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="747"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="747" />
         <source>information_popup_codec_install_error_text</source>
-        <extracomment>&quot;Le codec n&apos;a pas pu être installé.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le codec n'a pas pu être installé."</extracomment>
+        <translation>Impossibile installare il codec.</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="756"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="756" />
         <source>information_popup_codec_save_error_text</source>
-        <extracomment>&quot;Le codec n&apos;a pas pu être sauvegardé.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le codec n'a pas pu être sauvegardé."</extracomment>
+        <translation>Impossibile salvare il codec.</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="764"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="764" />
         <source>information_popup_codec_download_error_text</source>
-        <extracomment>&quot;Le codec n&apos;a pas pu être téléchargé.&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Le codec n'a pas pu être téléchargé."</extracomment>
+        <translation>Impossibile scaricare il codec.</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="770"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="770" />
         <source>loading_popup_codec_install_progress</source>
-        <extracomment>&quot;Téléchargement en cours …&quot;</extracomment>
-        <translation type="unfinished"></translation>
+        <extracomment>"Téléchargement en cours …"</extracomment>
+        <translation>Download in corso…</translation>
     </message>
     <message>
-        <location filename="../../view/Control/Tool/Helper/utils.js" line="805"/>
+        <location filename="../../view/Control/Tool/Helper/utils.js" line="805" />
         <source>okButton</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 <context>
     <name>SettingsCore</name>
     <message>
-        <location filename="../../core/setting/SettingsCore.cpp" line="447"/>
+        <location filename="../../core/setting/SettingsCore.cpp" line="447" />
         <source>info_popup_error_title</source>
         <translation>Errore</translation>
     </message>
@@ -8181,9 +8258,30 @@ Error in the chat</extracomment>
 <context>
     <name>EventLogProxy</name>
     <message>
-        <location filename="../../core/chat/message/EventLogProxy.cpp" line="65"/>
+        <location filename="../../core/chat/message/EventLogProxy.cpp" line="65" />
         <source>info_popup_error_title</source>
         <translation>Errore</translation>
+    </message>
+</context>
+<context>
+    <name>PbxSettingsLayout</name>
+    <message>
+        <location filename="../../view/Page/Layout/Settings/PbxSettingsLayout.qml" line="30" />
+        <source>settings_pbx_description</source>
+        <extracomment>"Utilisé pour le statut BLF en ligne/hors ligne et l'import des interlocuteurs"</extracomment>
+        <translation>Usato per lo stato online/offline BLF e l'importazione dei contatti.</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Layout/Settings/PbxSettingsLayout.qml" line="43" />
+        <source>settings_pbx_base_url_title</source>
+        <extracomment>"URL du PBX"</extracomment>
+        <translation>URL PBX</translation>
+    </message>
+    <message>
+        <location filename="../../view/Page/Layout/Settings/PbxSettingsLayout.qml" line="52" />
+        <source>settings_pbx_api_key_title</source>
+        <extracomment>"Clé API"</extracomment>
+        <translation>Chiave API</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## Summary

`it.ts` was 95% untranslated: 1255 of 1312 messages were `type="unfinished"` and fell back to the English translator at runtime. Translated all of them, plus a handful of strings introduced by other work in my fork (BLF dialog-info monitoring, MikoPBX integration, vCard import) that hadn't been synced into `it.ts` via `lupdate` yet, since those aren't upstream here — happy to drop that last part if it's out of scope for this PR.

Only 3 messages remain unfinished: their English source text is genuinely empty (blank strings), nothing to translate.

## Test plan

- [x] `it.ts` is valid, well-formed XML
- [x] Built on Windows (MSVC/Qt6/Ninja) against current `master`, 637/637 targets, no errors — `qrc_Linphone_translations` (the step that compiles all `.ts` files) succeeds
- [x] Verified `linphone.exe` launches and stays running (no crash)
- [ ] I could not verify the translated strings render correctly in a live Italian-language run of the app — Qt's `QLocale::system()` on Windows reads the OS's configured display language via a system API, and the machine I built this on has Italian *regional format* but English *display language*, so I couldn't force it to pick up `it.qm` at runtime without changing the machine's display language. The translation content and build pipeline are verified; visual verification of a subset in a real Italian-locale session would be appreciated before merging.
