### PR TITLE
Fix call window crash caused by binding to read-only ComboBox currentValue

### DIFF
--- a/Linphone/view/Control/Form/Settings/MultimediaSettings.qml
+++ b/Linphone/view/Control/Form/Settings/MultimediaSettings.qml
@@ -91,7 +91,9 @@ ColumnLayout {
                     Layout.preferredHeight: Utils.getSizeWithScreenRatio(49)
 					model: SettingsCpp.playbackDevices
 					oneLine: true
-					currentValue: SettingsCpp.playbackDevice
+					currentIndex: Utils.findIndex(model, function (entry) {
+						return Utils.equalObject(entry,SettingsCpp.playbackDevice)
+					})
 					textRole: 'display_name'
 					Connections {
 						enabled: mainItem.call || mainItem.forceUpdatingDeviceWithoutSaving
@@ -141,7 +143,10 @@ ColumnLayout {
 					Layout.preferredWidth: parent.width
                     Layout.preferredHeight: Utils.getSizeWithScreenRatio(49)
 					model: SettingsCpp.captureDevices
-					currentValue: SettingsCpp.captureDevice
+					oneLine: true
+					currentIndex: Utils.findIndex(model, function (entry) {
+						return Utils.equalObject(entry,SettingsCpp.captureDevice)
+					})
 					textRole: 'display_name'
 					Connections {
 						enabled: mainItem.call || mainItem.forceUpdatingDeviceWithoutSaving
@@ -154,7 +159,9 @@ ColumnLayout {
 						target: SettingsCpp
 						function onCaptureDeviceChanged() {
 							console.log("capture device changed in settings, force changing it in combobox")
-							inputAudioDeviceCBox.currentValue = SettingsCpp.captureDevice
+							inputAudioDeviceCBox.currentIndex = Utils.findIndex(inputAudioDeviceCBox.model, function (entry) {
+								return Utils.equalObject(entry,SettingsCpp.captureDevice)
+							})
 						}
 					}
 					accessibleLabel: qsTr("choose_something_accessible_name").arg(qsTr("multimedia_settings_microphone_title"))


### PR DESCRIPTION
Fixes #1016, the 6.2.1 crash where the app aborts every time a call is placed.

- Commit 7f6c270ed turned the playback and capture device combos in `MultimediaSettings.qml` into plain `ComboBox` items configured through `currentValue`. That resolves to the property inherited from `QtQuick.Controls.Basic.ComboBox`, which is read only before Qt 6.10. With the Qt 6.9.1 bundled in the official builds the component fails to compile, `CallsWindow.qml` cannot instantiate it, and `App::getOrCreateCallsWindow()` aborts. Qt 6.10 made `currentValue` writable, which is presumably why the regression went unnoticed in development.
- Drive the selection through `currentIndex` with `Utils.findIndex` and `Utils.equalObject` instead, the same way `ComboSetting.qml` does. This works on both older and newer Qt.
- The capture device force-sync handler assigned `currentValue` imperatively, a runtime `TypeError` before Qt 6.10. It now reassigns `currentIndex` the same way. The same assignment exists in that handler on master.
- Restore `oneLine` on the capture combo, which the same commit dropped when it replaced `ComboSetting`.

---

Aside: I am currently available for Qt/C++ contracting or full-time work. Contact: adrian@pascu.be.
